### PR TITLE
Optimization: store forceProtectionOff in context

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/context/ContextObject.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/context/ContextObject.java
@@ -5,10 +5,7 @@ import com.google.gson.GsonBuilder;
 import dev.aikido.agent_api.storage.Hostnames;
 import dev.aikido.agent_api.storage.RedirectNode;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.List;
+import java.util.*;
 
 public class ContextObject {
     protected String method;
@@ -26,6 +23,7 @@ public class ContextObject {
     protected boolean executedMiddleware;
     protected transient ArrayList<RedirectNode> redirectStartNodes;
     protected transient Map<String, Map<String, String>> cache = new HashMap<>();
+    protected transient Optional<Boolean> forcedProtectionOff = Optional.empty();
 
     // We store hostnames in the context object so we can match a given hostname (by DNS request)
     // with its port number (which we know by instrumenting the URLs that get requested).
@@ -98,6 +96,13 @@ public class ContextObject {
     public String getJSONBody() {
         Gson gson = new Gson();
         return gson.toJson(this.body);
+    }
+
+    public void setForcedProtectionOff(boolean forcedProtectionOff) {
+        this.forcedProtectionOff = Optional.of(forcedProtectionOff);
+    }
+    public Optional<Boolean> getForcedProtectionOff() {
+        return this.forcedProtectionOff;
     }
 
     public RouteMetadata getRouteMetadata() {

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/SkipVulnerabilityScanDecider.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/SkipVulnerabilityScanDecider.java
@@ -15,16 +15,21 @@ public final class SkipVulnerabilityScanDecider {
         if (context == null) {
             return true;
         }
-        ThreadCacheObject threadCache = ThreadCache.get(/* shouldFetch: */ false);
-        if (threadCache != null) {
-            List<Endpoint> matchedEndpoints = matchEndpoints(context.getRouteMetadata(), threadCache.getEndpoints());
-            if (matchedEndpoints != null) {
-                if (matchedEndpoints.stream().anyMatch(Endpoint::protectionForcedOff)) {
+        if (context.getForcedProtectionOff().isEmpty()) {
+            // cache value not present, go fetch
+            ThreadCacheObject threadCache = ThreadCache.get(/* shouldFetch: */ false);
+            if (threadCache != null) {
+                List<Endpoint> matchedEndpoints = matchEndpoints(context.getRouteMetadata(), threadCache.getEndpoints());
+                if (matchedEndpoints != null && matchedEndpoints.stream().anyMatch(Endpoint::protectionForcedOff)) {
                     // Protection is forced off on one of more of the matched endpoints :
-                    return true;
+                    context.setForcedProtectionOff(true);
+                } else {
+                    context.setForcedProtectionOff(false);
                 }
             }
         }
-        return false;
+
+        // Get stored forcedProtectionOff value from cache.
+        return context.getForcedProtectionOff().get();
     }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/SkipVulnerabilityScanDecider.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/SkipVulnerabilityScanDecider.java
@@ -18,14 +18,16 @@ public final class SkipVulnerabilityScanDecider {
         if (context.getForcedProtectionOff().isEmpty()) {
             // cache value not present, go fetch
             ThreadCacheObject threadCache = ThreadCache.get(/* shouldFetch: */ false);
-            if (threadCache != null) {
-                List<Endpoint> matchedEndpoints = matchEndpoints(context.getRouteMetadata(), threadCache.getEndpoints());
-                if (matchedEndpoints != null && matchedEndpoints.stream().anyMatch(Endpoint::protectionForcedOff)) {
-                    // Protection is forced off on one of more of the matched endpoints :
-                    context.setForcedProtectionOff(true);
-                } else {
-                    context.setForcedProtectionOff(false);
-                }
+            if (threadCache == null) {
+                return false; // thread cache not defined, unable to loop
+            }
+
+            List<Endpoint> matchedEndpoints = matchEndpoints(context.getRouteMetadata(), threadCache.getEndpoints());
+            if (matchedEndpoints != null && matchedEndpoints.stream().anyMatch(Endpoint::protectionForcedOff)) {
+                // Protection is forced off on one of more of the matched endpoints :
+                context.setForcedProtectionOff(true);
+            } else {
+                context.setForcedProtectionOff(false);
             }
         }
 

--- a/agent_api/src/test/java/context/ContextObjectTest.java
+++ b/agent_api/src/test/java/context/ContextObjectTest.java
@@ -90,5 +90,19 @@ class ContextObjectTest {
         String result = context.getHeader("Empty-Header");
         assertNull(result);
     }
+
+    @Test
+    public void testOptionalForcedProtectionOffIsEmpty() {
+        assertTrue(context.getForcedProtectionOff().isEmpty());
+    }
+
+    @Test
+    public void testSettingForcedProtectionOff() {
+        context.setForcedProtectionOff(true);
+        assertTrue(context.getForcedProtectionOff().get());
+
+        context.setForcedProtectionOff(false);
+        assertFalse(context.getForcedProtectionOff().get());
+    }
 }
 

--- a/agent_api/src/test/java/vulnerabilities/SkipVulnerabilityScanDeciderTest.java
+++ b/agent_api/src/test/java/vulnerabilities/SkipVulnerabilityScanDeciderTest.java
@@ -203,4 +203,19 @@ public class SkipVulnerabilityScanDeciderTest {
                 new EmptySampleContextObject("", "/api/login", "POST")
         ));
     }
+
+    @Test
+    public void testUsesCache() {
+        ContextObject ctx = new EmptySampleContextObject("", "/api/login", "POST");
+        assertTrue(ctx.getForcedProtectionOff().isEmpty());
+
+        assertFalse(SkipVulnerabilityScanDecider.shouldSkipVulnerabilityScan(ctx));
+        assertTrue(ctx.getForcedProtectionOff().isPresent());
+        assertFalse(ctx.getForcedProtectionOff().get());
+
+        assertFalse(SkipVulnerabilityScanDecider.shouldSkipVulnerabilityScan(ctx));
+
+        ctx.setForcedProtectionOff(true);
+        assertTrue(SkipVulnerabilityScanDecider.shouldSkipVulnerabilityScan(ctx));
+    }
 }


### PR DESCRIPTION
Optimizes CPU cycles
Makes sure we don't have to go matching endpoints