### PR TITLE
SpringAnnotationCollector, add error log when no Spring context

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/SpringAnnotationCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/SpringAnnotationCollector.java
@@ -36,8 +36,7 @@ public final class SpringAnnotationCollector {
         if (context == null) {
             logger.error(
                 "Received Spring Annotations, but no context set." +
-                "This is likely because of incompatibility with your current Spring version or " +
-                "because of a bug in the Spring wrapper.");
+                "This is likely because of an incompatibility with your current Spring setup.");
             return;
         }
 


### PR DESCRIPTION
This should only happen when theres a bug with the wrapping.