### PR TITLE
do a context check in FileCollector itself

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/FileCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/FileCollector.java
@@ -1,5 +1,6 @@
 package dev.aikido.agent_api.collectors;
 
+import dev.aikido.agent_api.context.Context;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
 import dev.aikido.agent_api.storage.statistics.OperationKind;
@@ -21,6 +22,11 @@ public final class FileCollector {
     public static void report(Object filePath, String operation, int depth) {
         if (filePath == null) {
             return; // Make sure filePath is defined
+        }
+        if (Context.get() == null) {
+            // The FileCollector tries to extract file paths from the `Object filePath`, so we don't want to wait
+            // for a context check in `scanForGivenVulnerability`
+            return;
         }
         logger.trace("Scan on %s for file: %s", operation, filePath);
         StatisticsStore.registerCall(operation, OperationKind.FS_OP);


### PR DESCRIPTION
Do an early return in FileCollector itself, instead of waiting for vulnerability scan