### PR TITLE
Check if Accept-Encoding header contains gzip (mock server)

### DIFF
--- a/end2end/server/mock_aikido_core.py
+++ b/end2end/server/mock_aikido_core.py
@@ -97,6 +97,13 @@ def get_runtime_config():
 
 @app.route('/api/runtime/firewall/lists', methods=['GET'])
 def get_fw_lists():
+    accept_encoding = request.headers.get('Accept-Encoding', '').lower()
+    if 'gzip' not in accept_encoding:
+        return jsonify({
+            "success": False,
+            "error": "Accept-Encoding header must include 'gzip' for firewall lists endpoint"
+        }), 400
+
     json_data = json.dumps(responses["lists"])
     compressed_data = gzip.compress(json_data.encode('utf-8'))
 


### PR DESCRIPTION
Reject request otherwise: allows us to catch missing gzip headers