### PR TITLE
Adds more shell separators for injection check

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/shell_injection/ShellSyntaxChecker.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/shell_injection/ShellSyntaxChecker.java
@@ -10,7 +10,7 @@ import static dev.aikido.agent_api.vulnerabilities.shell_injection.ShellCommands
 public final class ShellSyntaxChecker {
     private ShellSyntaxChecker() {}
     private static final List<String> SEPARATORS = Arrays.asList(
-            " ", "\t", "\n", ";", "&", "|", "(", ")", "<", ">", "\r", "\f", "\u000B"
+            " ", "\t", "\n", ";", "&", "|", "(", ")", "<", ">", "\r", "\f"
     );
 
     public static boolean containsShellSyntax(String command, String userInput) {

--- a/agent_api/src/test/java/vulnerabilities/shell_injection/ShellInjectionDetectorTest.java
+++ b/agent_api/src/test/java/vulnerabilities/shell_injection/ShellInjectionDetectorTest.java
@@ -448,11 +448,4 @@ public class ShellInjectionDetectorTest {
         assertIsShellInjection("ls\frm", "rm");
         assertIsShellInjection("echo test\frm -rf /", "rm");
     }
-
-    @Test
-    void testVerticalTabAsSeparator() {
-        // \u000B (vertical tab) as separator before dangerous command
-        assertIsShellInjection("ls\u000Brm", "rm");
-        assertIsShellInjection("echo test\u000Brm -rf /", "rm");
-    }
 }


### PR DESCRIPTION
Adds \r, \f and \v as separators

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added carriage return and form feed as shell separators


<sup>[More info](https://app.aikido.dev/featurebranch/scan/81210550?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->