### PR TITLE
Update: add \r and \f to dangerous shell chars for when the command is exactly the same

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/shell_injection/DangerousShellChars.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/shell_injection/DangerousShellChars.java
@@ -7,7 +7,7 @@ public final class DangerousShellChars {
     private DangerousShellChars() {}
     private static final List<String> DANGEROUS_CHARS = Arrays.asList(
             "#", "!", "\"", "$", "&", "'", "(", ")", "*", ";", "<", "=", ">", "?",
-            "[", "\\", "]", "^", "`", "{", "|", "}", " ", "\n", "\t", "~"
+            "[", "\\", "]", "^", "`", "{", "|", "}", " ", "\n", "\t", "~", "\r", "\f"
     );
 
     public static boolean containDangerousCharacter(String userInput) {

--- a/agent_api/src/test/java/vulnerabilities/shell_injection/ShellInjectionDetectorTest.java
+++ b/agent_api/src/test/java/vulnerabilities/shell_injection/ShellInjectionDetectorTest.java
@@ -439,6 +439,7 @@ public class ShellInjectionDetectorTest {
     void testCarriageReturnAsSeparator() {
         // \r (carriage return) as separator before dangerous command
         assertIsShellInjection("ls\rrm", "rm");
+        assertIsShellInjection("sleep\r5", "sleep\r5");
         assertIsShellInjection("echo test\rrm -rf /", "rm");
     }
 
@@ -446,6 +447,16 @@ public class ShellInjectionDetectorTest {
     void testFormFeedAsSeparator() {
         // \f (form feed) as separator before dangerous command
         assertIsShellInjection("ls\frm", "rm");
+        assertIsShellInjection("sleep\f5", "sleep\f5");
         assertIsShellInjection("echo test\frm -rf /", "rm");
+    }
+
+    @Test
+    void testCommandExactlyMatchesUserInputWithSeparators() {
+        // When command equals userInput and contains \r or \f separators
+        assertIsShellInjection("ls\rrm", "ls\rrm");
+        assertIsShellInjection("ls\frm", "ls\frm");
+        assertIsShellInjection("echo\rcat /etc/passwd", "echo\rcat /etc/passwd");
+        assertIsShellInjection("echo\fcat /etc/passwd", "echo\fcat /etc/passwd");
     }
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added carriage return and form feed to dangerous characters


<sup>[More info](https://app.aikido.dev/featurebranch/scan/81228825?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->