### PR TITLE
Block SQL queries that fail tokenization

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/helpers/env/BlockInvalidSqlEnv.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/helpers/env/BlockInvalidSqlEnv.java
@@ -1,0 +1,10 @@
+package dev.aikido.agent_api.helpers.env;
+
+public class BlockInvalidSqlEnv extends BooleanEnv {
+    private static final String environmentName = "AIKIDO_BLOCK_INVALID_SQL";
+    private static final boolean defaultValue = true;
+
+    public BlockInvalidSqlEnv() {
+        super(environmentName, defaultValue);
+    }
+}

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/RustSQLInterface.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/RustSQLInterface.java
@@ -24,20 +24,19 @@ public final class RustSQLInterface {
         int detect_sql_injection(String query, long queryLen, String userinput, long userinputLen, int dialect);
     }
 
-    public static boolean detectSqlInjection(String query, String userInput, Dialect dialect) {
+    public static int detectSqlInjection(String query, String userInput, Dialect dialect) {
         int dialectInteger = dialect.getDialectInteger();
         try {
             SqlLib lib = loadLibrary();
             if (lib != null) {
                 long queryLen = query != null ? query.getBytes(StandardCharsets.UTF_8).length : 0;
                 long userInputLen = userInput != null ? userInput.getBytes(StandardCharsets.UTF_8).length : 0;
-                int result = lib.detect_sql_injection(query, queryLen, userInput, userInputLen, dialectInteger);
-                return result == 1;
+                return lib.detect_sql_injection(query, queryLen, userInput, userInputLen, dialectInteger);
             }
         } catch (Throwable e) {
             logger.trace(e);
         }
-        return false;
+        return 0;
     }
     public static SqlLib loadLibrary() {
         String path = getPathForBinary();

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/SqlDetector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/SqlDetector.java
@@ -1,9 +1,11 @@
 package dev.aikido.agent_api.vulnerabilities.sql_injection;
 
+import dev.aikido.agent_api.helpers.env.BlockInvalidSqlEnv;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
 import dev.aikido.agent_api.vulnerabilities.Detector;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -23,21 +25,32 @@ public class SqlDetector implements Detector {
         }
         String query = arguments[0];
         Dialect dialect = new Dialect(arguments[1]);
-        boolean detectedAttack = detectSqlInjection(query, userInput, dialect);
-        if (detectedAttack) {
+        int result = detectSqlInjection(query, userInput, dialect);
+
+        if (result == 1) {
             Map<String, String> metadata = Map.of(
                 "sql", query,
                 "dialect", dialect.getHumanName()
             );
-            return new DetectorResult(/* detectedAttack*/ true, metadata, SQLInjectionException.get(dialect));
+            return new DetectorResult(true, metadata, SQLInjectionException.get(dialect));
         }
+
+        if (result == 3 && new BlockInvalidSqlEnv().getValue()) {
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("sql", query);
+            metadata.put("dialect", dialect.getHumanName());
+            metadata.put("failedToTokenize", "true");
+            return new DetectorResult(true, metadata, SQLInjectionException.get(dialect));
+        }
+
         return new DetectorResult();
     }
-    public static boolean detectSqlInjection(String query, String userInput, Dialect dialect) {
+
+    public static int detectSqlInjection(String query, String userInput, Dialect dialect) {
         String queryLower = query.toLowerCase();
         String userInputLower = userInput.toLowerCase();
         if (shouldReturnEarly(queryLower, userInputLower)) {
-            return false;
+            return 0;
         }
         return RustSQLInterface.detectSqlInjection(queryLower, userInputLower, dialect);
     }

--- a/agent_api/src/test/java/vulnerabilities/RustSQLInterfaceTest.java
+++ b/agent_api/src/test/java/vulnerabilities/RustSQLInterfaceTest.java
@@ -4,15 +4,14 @@ import dev.aikido.agent_api.vulnerabilities.sql_injection.Dialect;
 import dev.aikido.agent_api.vulnerabilities.sql_injection.RustSQLInterface;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RustSQLInterfaceTest {
     @Test
     public void testItWorks() {
-        boolean injectionResult = RustSQLInterface.detectSqlInjection("SELECT * FROM table;", "table;", new Dialect("postgresql"));
-        assertTrue(injectionResult);
+        int injectionResult = RustSQLInterface.detectSqlInjection("SELECT * FROM table;", "table;", new Dialect("postgresql"));
+        assertEquals(1, injectionResult);
         injectionResult = RustSQLInterface.detectSqlInjection("SELECT * FROM table;", "table", new Dialect("postgresql"));
-        assertFalse(injectionResult);
+        assertEquals(0, injectionResult);
     }
 }

--- a/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
+++ b/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static dev.aikido.agent_api.vulnerabilities.sql_injection.SqlDetector.detectSqlInjection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SqlInjectionTest {
     private void isNotSqlInjection(String sql, String input, String dialect) {

--- a/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
+++ b/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
@@ -7,30 +7,37 @@ import org.junit.jupiter.api.Test;
 import static dev.aikido.agent_api.vulnerabilities.sql_injection.SqlDetector.detectSqlInjection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SqlInjectionTest {
     private void isNotSqlInjection(String sql, String input, String dialect) {
-        int result;
         if ("mysql".equals(dialect) || "all".equals(dialect)) {
-            result = detectSqlInjection(sql, input, new Dialect("mysql"));
-            assertNotEquals(1, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
+            int result = detectSqlInjection(sql, input, new Dialect("mysql"));
+            assertEquals(0, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
         }
         if ("postgresql".equals(dialect) || "all".equals(dialect)) {
-            result = detectSqlInjection(sql, input, new Dialect("postgresql"));
-            assertNotEquals(1, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
+            int result = detectSqlInjection(sql, input, new Dialect("postgresql"));
+            assertEquals(0, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
         }
     }
     private void isSqlInjection(String sql, String input, String dialect) {
-        int result;
         if ("mysql".equals(dialect) || "all".equals(dialect)) {
-            result = detectSqlInjection(sql, input, new Dialect("mysql"));
+            int result = detectSqlInjection(sql, input, new Dialect("mysql"));
             assertEquals(1, result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
         }
         if ("postgresql".equals(dialect) || "all".equals(dialect)) {
-            result = detectSqlInjection(sql, input, new Dialect("postgresql"));
+            int result = detectSqlInjection(sql, input, new Dialect("postgresql"));
             assertEquals(1, result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
+        }
+    }
+    private void isSqlTokenizeError(String sql, String input, String dialect) {
+        if ("mysql".equals(dialect) || "all".equals(dialect)) {
+            int result = detectSqlInjection(sql, input, new Dialect("mysql"));
+            assertEquals(3, result, String.format("Expected SQL tokenize error for SQL: %s and input: %s", sql, input));
+        }
+        if ("postgresql".equals(dialect) || "all".equals(dialect)) {
+            int result = detectSqlInjection(sql, input, new Dialect("postgresql"));
+            assertEquals(3, result, String.format("Expected SQL tokenize error for SQL: %s and input: %s", sql, input));
         }
     }
 
@@ -166,17 +173,8 @@ public class SqlInjectionTest {
         assertFalse(SqlDetector.shouldReturnEarly("SELECT * FROM users; DROP TABLE", "users; DROP TABLE"));
     }
 
-    /**
-     * Moved :
-     * is_sql_injection("SELECT * FROM users WHERE id = 'users\\'", "users\\")
-     * is_sql_injection("SELECT * FROM users WHERE id = 'users\\\\'", "users\\\\")
-     * to is_not_sql_injection. Reason : Invalid SQL.
-     */
     @Test
     public void testAllowEscapeSequences() {
-        // Invalid queries:
-        isNotSqlInjection("SELECT * FROM users WHERE id = 'users\\'", "users\\", "all");
-        isNotSqlInjection("SELECT * FROM users WHERE id = 'users\\\\'", "users\\\\", "all");
         isNotSqlInjection("SELECT * FROM users WHERE id = '\nusers'", "\nusers", "all");
         isNotSqlInjection("SELECT * FROM users WHERE id = '\rusers'", "\rusers", "all");
         isNotSqlInjection("SELECT * FROM users WHERE id = '\tusers'", "\tusers", "all");
@@ -220,8 +218,7 @@ public class SqlInjectionTest {
                 "SELECT * FROM comments WHERE comment = \"I\\`m writing you\"", "I`m writing you", "all"
         );
 
-        // Invalid query (strings don't terminate)
-        isNotSqlInjection(
+        isSqlTokenizeError(
                 "SELECT * FROM comments WHERE comment = 'I'm writing you'", "I'm writing you", "all"
         );
 
@@ -373,6 +370,12 @@ public class SqlInjectionTest {
         String expectedSqlInjection = "' OR 1=1 -- a";
 
         isSqlInjection(sql, expectedSqlInjection, "all");
+    }
+
+    @Test
+    public void testUnterminatedStrings() {
+        isSqlTokenizeError("SELECT * FROM users WHERE id = 'users\\'", "users\\", "all");
+        isSqlTokenizeError("SELECT * FROM users WHERE id = 'users\\\\'", "users\\\\", "all");
     }
 
     /**

--- a/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
+++ b/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
@@ -5,30 +5,30 @@ import dev.aikido.agent_api.vulnerabilities.sql_injection.SqlDetector;
 import org.junit.jupiter.api.Test;
 
 import static dev.aikido.agent_api.vulnerabilities.sql_injection.SqlDetector.detectSqlInjection;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class SqlInjectionTest {
     private void isNotSqlInjection(String sql, String input, String dialect) {
-        boolean result;
+        int result;
         if ("mysql".equals(dialect) || "all".equals(dialect)) {
             result = detectSqlInjection(sql, input, new Dialect("mysql"));
-            assertFalse(result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
+            assertNotEquals(1, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
         }
         if ("postgresql".equals(dialect) || "all".equals(dialect)) {
             result = detectSqlInjection(sql, input, new Dialect("postgresql"));
-            assertFalse(result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
+            assertNotEquals(1, result, String.format("Expected no SQL injection for SQL: %s and input: %s", sql, input));
         }
     }
     private void isSqlInjection(String sql, String input, String dialect) {
-        boolean result;
+        int result;
         if ("mysql".equals(dialect) || "all".equals(dialect)) {
             result = detectSqlInjection(sql, input, new Dialect("mysql"));
-            assertTrue(result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
+            assertEquals(1, result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
         }
         if ("postgresql".equals(dialect) || "all".equals(dialect)) {
             result = detectSqlInjection(sql, input, new Dialect("postgresql"));
-            assertTrue(result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
+            assertEquals(1, result, String.format("Expected SQL injection for SQL: %s and input: %s", sql, input));
         }
     }
 

--- a/docs/invalid-sql-queries.md
+++ b/docs/invalid-sql-queries.md
@@ -1,0 +1,8 @@
+# Blocking invalid SQL queries
+
+Zen blocks SQL queries that it can't tokenize when they contain user input. This prevents attackers from bypassing SQL injection detection with malformed queries. For example, ClickHouse ignores invalid SQL after `;`, and SQLite runs queries before an unclosed `/*` comment.
+
+This is on by default. In blocking mode, these queries are blocked. In detection-only mode, they are reported but still executed.
+
+If you see false positives (legitimate queries being blocked), set the
+`AIKIDO_BLOCK_INVALID_SQL` environment variable to `false`.


### PR DESCRIPTION
Our SQL injection detection tokenizes queries to check them. If the tokenizer can't parse a query, we skip it and the query goes through. Some databases still execute partially valid queries though: ClickHouse ignores junk after ; and SQLite runs everything before an unclosed /*.

Now when user input shows up in a query we can't tokenize, we treat it as an attack. On by default, opt out with AIKIDO_BLOCK_INVALID_SQL=false.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated detector to treat tokenize failures as attacks behind env toggle

**🔧 Refactors**
* Changed native SQL detector interface to return integer status codes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97410762?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->