### PR TITLE
Allow user ids to be excluded from rate limiting

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -44,7 +44,7 @@ jobs:
                   cp firewall-java/.github/workflows/Dockerfile.qa zen-demo-java/Dockerfile
 
             - name: Run Firewall QA Tests
-              uses: AikidoSec/firewall-tester-action@v1.0.0
+              uses: AikidoSec/firewall-tester-action@v1.0.12
               with:
                   dockerfile_path: ./zen-demo-java/Dockerfile
                   app_port: 8080

--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -44,7 +44,7 @@ jobs:
                   cp firewall-java/.github/workflows/Dockerfile.qa zen-demo-java/Dockerfile
 
             - name: Run Firewall QA Tests
-              uses: AikidoSec/firewall-tester-action@v1.0.12
+              uses: AikidoSec/firewall-tester-action@v1.0.0
               with:
                   dockerfile_path: ./zen-demo-java/Dockerfile
                   app_port: 8080

--- a/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/APIResponse.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/APIResponse.java
@@ -15,6 +15,7 @@ public record APIResponse(
         boolean blockNewOutgoingRequests,
         List<Domain> domains,
         boolean receivedAnyStats,
-        boolean block
+        boolean block,
+        List<String> excludedUserIdsFromRateLimiting
 ) {
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/ReportingApiHTTP.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/ReportingApiHTTP.java
@@ -152,7 +152,7 @@ public class ReportingApiHTTP extends ReportingApi {
         return new APIResponse(
                 false, // Success
                 error,
-                0, null, null, null, false, null, false, false // Unimportant values.
+                0, null, null, null, false, null, false, false, null // Unimportant values.
         );
     }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/ratelimiting/ShouldRateLimit.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/ratelimiting/ShouldRateLimit.java
@@ -23,6 +23,10 @@ public final class ShouldRateLimit {
             return NO_RATE_LIMIT;
         }
 
+        if (user != null && ServiceConfigStore.getConfig().isUserExcludedFromRateLimiting(user.id())) {
+            return NO_RATE_LIMIT;
+        }
+
         long windowSizeInMS = rateLimitedEndpoint.getRateLimiting().windowSizeInMS();
         long maxRequests = rateLimitedEndpoint.getRateLimiting().maxRequests();
 

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
@@ -24,6 +24,7 @@ public class ServiceConfiguration {
     private boolean middlewareInstalled;
     private IPList bypassedIPs = new IPList();
     private HashSet<String> blockedUserIDs = new HashSet<>();
+    private HashSet<String> excludedUserIdsFromRateLimiting = new HashSet<>();
     private List<Endpoint> endpoints = new ArrayList<>();
     private OutboundDomains outboundDomains = new OutboundDomains();
 
@@ -42,6 +43,9 @@ public class ServiceConfiguration {
         }
         if (apiResponse.blockedUserIds() != null) {
             this.blockedUserIDs = new HashSet<>(apiResponse.blockedUserIds());
+        }
+        if (apiResponse.excludedUserIdsFromRateLimiting() != null) {
+            this.excludedUserIdsFromRateLimiting = new HashSet<>(apiResponse.excludedUserIdsFromRateLimiting());
         }
         if (apiResponse.endpoints() != null) {
             this.endpoints = apiResponse.endpoints();
@@ -76,6 +80,10 @@ public class ServiceConfiguration {
 
     public boolean isUserBlocked(String userId) {
         return this.blockedUserIDs.contains(userId);
+    }
+
+    public boolean isUserExcludedFromRateLimiting(String userId) {
+        return this.excludedUserIdsFromRateLimiting.contains(userId);
     }
 
     public boolean isIpBypassed(String ip) {

--- a/agent_api/src/test/java/ShouldBlockRequestTest.java
+++ b/agent_api/src/test/java/ShouldBlockRequestTest.java
@@ -87,7 +87,7 @@ public class ShouldBlockRequestTest {
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
                 true, "", getUnixTimeMS(), List.of(),
                 /* blockedUserIds */ List.of("ID1", "ID2", "ID3"), List.of(),
-                false, null, false, true
+                false, null, false, true, List.of()
         ));
         var res2 = ShouldBlockRequest.shouldBlockRequest();
         assertTrue(res2.block());
@@ -227,7 +227,7 @@ public class ShouldBlockRequestTest {
         );
         List<String> blockedUserIds = List.of("ID1");
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-                true, "", getUnixTimeMS(), endpoints, blockedUserIds, List.of(), false, null,true, false
+                true, "", getUnixTimeMS(), endpoints, blockedUserIds, List.of(), false, null,true, false, List.of()
         ));
 
         // Call the method

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -47,7 +47,7 @@ public class DNSRecordCollectorTest {
         AttackQueue.clear();
         // Reset domain config
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-            true, null, 0L, null, null, null, false, List.of(), true, false
+            true, null, 0L, null, null, null, false, List.of(), true, false, List.of()
         ));
     }
 
@@ -116,7 +116,7 @@ public class DNSRecordCollectorTest {
     public void testBlockedDomain() {
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
             true, null, 0L, null, null, null,
-            false, List.of(new Domain("blocked.example.com", "block")), true, true
+            false, List.of(new Domain("blocked.example.com", "block")), true, true, List.of()
         ));
         assertThrows(BlockedOutboundException.class, () ->
             DNSRecordCollector.report("blocked.example.com", new InetAddress[]{inetAddress1})
@@ -127,7 +127,7 @@ public class DNSRecordCollectorTest {
     public void testAllowedDomainNotBlocked() {
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
             true, null, 0L, null, null, null,
-            false, List.of(new Domain("allowed.example.com", "allow")), true, true
+            false, List.of(new Domain("allowed.example.com", "allow")), true, true, List.of()
         ));
         assertDoesNotThrow(() ->
             DNSRecordCollector.report("allowed.example.com", new InetAddress[]{inetAddress1})
@@ -138,7 +138,7 @@ public class DNSRecordCollectorTest {
     public void testUnknownDomainBlockedWhenBlockNewOutgoingRequests() {
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
             true, null, 0L, null, null, null,
-            true, List.of(), true, true
+            true, List.of(), true, true, List.of()
         ));
         assertThrows(BlockedOutboundException.class, () ->
             DNSRecordCollector.report("unknown.example.com", new InetAddress[]{inetAddress1})

--- a/agent_api/src/test/java/collectors/WebRequestCollectorTest.java
+++ b/agent_api/src/test/java/collectors/WebRequestCollectorTest.java
@@ -212,7 +212,7 @@ class WebRequestCollectorTest {
 
         List<String> bypassedIps = List.of("192.168.1.1");
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false
+                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false, List.of()
         ));
 
 
@@ -231,7 +231,7 @@ class WebRequestCollectorTest {
 
         List<String> bypassedIps = List.of("192.168.1.1");
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false
+                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false, List.of()
         ));
 
         WebRequestCollector.Res response = WebRequestCollector.report(contextObject);
@@ -251,7 +251,7 @@ class WebRequestCollectorTest {
 
         List<String> bypassedIps = List.of("192.168.1.1");
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false
+                true, "", getUnixTimeMS(), List.of(), List.of(), bypassedIps, false, null, true, false, List.of()
         ));
 
 

--- a/agent_api/src/test/java/ratelimiting/ShouldRateLimitTest.java
+++ b/agent_api/src/test/java/ratelimiting/ShouldRateLimitTest.java
@@ -304,4 +304,40 @@ public class ShouldRateLimitTest {
         assertEquals(new ShouldRateLimit.RateLimitDecision(true, "group"),
             ShouldRateLimit.shouldRateLimit(metadata, null, "group1", "4.3.2.1"));
     }
+
+    @Test
+    public void testDoesNotRateLimitExcludedUsers() {
+        List<Endpoint> endpoints = new ArrayList<>();
+        endpoints.add(new Endpoint("POST", "/login",
+                /*maxRequests*/ 3, /*windowSizeMS*/ 1000, List.of(),
+                false, false, true));
+        utils.EmptyAPIResponses.setEmptyConfigWithEndpointListAndExcludedUsers(
+                endpoints, List.of("excluded-user-id"));
+
+        RouteMetadata routeMetadata = createRouteMetadata("POST", "/login");
+        User excludedUser = new User("excluded-user-id", "John Doe", "1.1.1.1", 0);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(new ShouldRateLimit.RateLimitDecision(false, null),
+                    ShouldRateLimit.shouldRateLimit(routeMetadata, excludedUser, null, "1.2.3.4"));
+        }
+    }
+
+    @Test
+    public void testDoesNotRateLimitExcludedUsersInGroup() {
+        List<Endpoint> endpoints = new ArrayList<>();
+        endpoints.add(new Endpoint("POST", "/login",
+                /*maxRequests*/ 3, /*windowSizeMS*/ 1000, List.of(),
+                false, false, true));
+        utils.EmptyAPIResponses.setEmptyConfigWithEndpointListAndExcludedUsers(
+                endpoints, List.of("excluded-user-id"));
+
+        RouteMetadata routeMetadata = createRouteMetadata("POST", "/login");
+        User excludedUser = new User("excluded-user-id", "John Doe", "1.1.1.1", 0);
+
+        for (int i = 0; i < 5; i++) {
+            assertEquals(new ShouldRateLimit.RateLimitDecision(false, null),
+                    ShouldRateLimit.shouldRateLimit(routeMetadata, excludedUser, "group1", "1.2.3.4"));
+        }
+    }
 }

--- a/agent_api/src/test/java/storage/ServiceConfigStoreTest.java
+++ b/agent_api/src/test/java/storage/ServiceConfigStoreTest.java
@@ -17,7 +17,7 @@ public class ServiceConfigStoreTest {
         // Reset to a known state: no domains, blockNewOutgoingRequests=false
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
                 true, null, 0L, null, null, null,
-                false, null, true, false
+                false, null, true, false, null
         ));
     }
 
@@ -32,7 +32,7 @@ public class ServiceConfigStoreTest {
                 true, null, 0L, null, null, null,
                 false,
                 List.of(new Domain("blocked.com", "block")),
-                true, false
+                true, false, null
         ));
         assertTrue(ServiceConfigStore.shouldBlockOutgoingRequest("blocked.com"));
     }
@@ -43,7 +43,7 @@ public class ServiceConfigStoreTest {
                 true, null, 0L, null, null, null,
                 true,
                 List.of(new Domain("allowed.com", "allow")),
-                true, false
+                true, false, null
         ));
         assertFalse(ServiceConfigStore.shouldBlockOutgoingRequest("allowed.com"));
     }
@@ -54,7 +54,7 @@ public class ServiceConfigStoreTest {
                 true, null, 0L, null, null, null,
                 true,
                 List.of(new Domain("allowed.com", "allow")),
-                true, false
+                true, false, null
         ));
         assertTrue(ServiceConfigStore.shouldBlockOutgoingRequest("unknown.com"));
     }

--- a/agent_api/src/test/java/storage/ServiceConfigurationTest.java
+++ b/agent_api/src/test/java/storage/ServiceConfigurationTest.java
@@ -38,7 +38,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -68,7 +69,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 false,
-                false
+                false,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -309,7 +311,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 false,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -329,7 +332,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         ));
 
         assertFalse(serviceConfiguration.isIpBypassed("192.168.1.1"));
@@ -347,7 +351,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -369,10 +374,44 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         ));
 
         assertFalse(serviceConfiguration.isUserBlocked("user1"));
+    }
+
+    @Test
+    public void testExcludedUserIdsFromRateLimiting() {
+        // Initially empty
+        assertFalse(serviceConfiguration.isUserExcludedFromRateLimiting("user1"));
+
+        // Populated via updateConfig
+        serviceConfiguration.updateConfig(new APIResponse(
+                true, null, 12345L, null, null, null,
+                false, null, true, true,
+                List.of("user1", "user2")
+        ));
+        assertTrue(serviceConfiguration.isUserExcludedFromRateLimiting("user1"));
+        assertTrue(serviceConfiguration.isUserExcludedFromRateLimiting("user2"));
+        assertFalse(serviceConfiguration.isUserExcludedFromRateLimiting("user3"));
+
+        // Subsequent update replaces the set
+        serviceConfiguration.updateConfig(new APIResponse(
+                true, null, 12345L, null, null, null,
+                false, null, true, true,
+                List.of("user3")
+        ));
+        assertFalse(serviceConfiguration.isUserExcludedFromRateLimiting("user1"));
+        assertTrue(serviceConfiguration.isUserExcludedFromRateLimiting("user3"));
+
+        // Empty list clears all
+        serviceConfiguration.updateConfig(new APIResponse(
+                true, null, 12345L, null, null, null,
+                false, null, true, true,
+                Collections.emptyList()
+        ));
+        assertFalse(serviceConfiguration.isUserExcludedFromRateLimiting("user3"));
     }
 
     @Test
@@ -387,7 +426,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -408,7 +448,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -428,7 +469,8 @@ public class ServiceConfigurationTest {
                 false,
                 null,
                 true,
-                true
+                true,
+                null
         );
 
         serviceConfiguration.updateConfig(apiResponse);
@@ -573,7 +615,7 @@ public class ServiceConfigurationTest {
                 true, null, 0L, null, null, null,
                 true,
                 List.of(new Domain("example.com", "block"), new Domain("allowed.com", "allow")),
-                true, true
+                true, true, null
         );
         serviceConfiguration.updateConfig(apiResponse);
 
@@ -588,7 +630,7 @@ public class ServiceConfigurationTest {
                 true, null, 0L, null, null, null,
                 false,
                 List.of(new Domain("example.com", "block"), new Domain("allowed.com", "allow")),
-                true, true
+                true, true, null
         );
         serviceConfiguration.updateConfig(apiResponse2);
 

--- a/agent_api/src/test/java/utils/EmptyAPIResponses.java
+++ b/agent_api/src/test/java/utils/EmptyAPIResponses.java
@@ -12,14 +12,19 @@ import static dev.aikido.agent_api.helpers.UnixTimeMS.getUnixTimeMS;
 
 public class EmptyAPIResponses {
     public final static APIResponse emptyAPIResponse = new APIResponse(
-            true, "", UnixTimeMS.getUnixTimeMS(), List.of(), List.of(), List.of(), false, null,true, false
+            true, "", UnixTimeMS.getUnixTimeMS(), List.of(), List.of(), List.of(), false, null,true, false, List.of()
     );
     public final static ReportingApi.APIListsResponse emptyAPIListsResponse = new ReportingApi.APIListsResponse(
             List.of(), List.of(), List.of(), null, null, List.of()
     );
     public static void setEmptyConfigWithEndpointList(List<Endpoint> endpoints) {
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
-                true, "", getUnixTimeMS(), endpoints, List.of(), List.of(), false, null, true, false
+                true, "", getUnixTimeMS(), endpoints, List.of(), List.of(), false, null, true, false, List.of()
+        ));
+    }
+    public static void setEmptyConfigWithEndpointListAndExcludedUsers(List<Endpoint> endpoints, List<String> excludedUserIds) {
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+                true, "", getUnixTimeMS(), endpoints, List.of(), List.of(), false, null, true, false, excludedUserIds
         ));
     }
 }


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added excluded user IDs support and propagated through config

**⚡ Enhancements**
* Skipped rate limiting for configured excluded users in logic

**🔧 Refactors**
* Adjusted unsuccessful API response construction to match new signature


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103311081?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->