### PR TITLE
Change response messages slightly for qa tests

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
@@ -97,7 +97,7 @@ public class ServiceConfiguration {
         // Check for allowed ip addresses (i.e. only one country is allowed to visit the site)
         // Always allow access from private IP addresses (those include local IP addresses)
         if (!isPrivateIp(ip) && !firewallLists.matchesAllowedIps(ip)) {
-            return new BlockedResult(true, "not in allowlist");
+            return new BlockedResult(true, "not allowed");
         }
 
         // Check for monitored IP addresses

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/outbound_blocking/BlockedOutboundException.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/outbound_blocking/BlockedOutboundException.java
@@ -8,7 +8,7 @@ public class BlockedOutboundException extends AikidoException {
     }
 
     public static BlockedOutboundException get() {
-        String defaultMsg = generateDefaultMessage("an outbound request");
+        String defaultMsg = generateDefaultMessage("an outbound connection");
         return new BlockedOutboundException(defaultMsg);
     }
 }

--- a/agent_api/src/test/java/collectors/WebRequestCollectorTest.java
+++ b/agent_api/src/test/java/collectors/WebRequestCollectorTest.java
@@ -157,7 +157,7 @@ class WebRequestCollectorTest {
         contextObject.setIp("4.4.4.4");
         response = WebRequestCollector.report(contextObject);
         assertNotNull(response);
-        assertEquals("Your IP address is blocked. Reason: not in allowlist (Your IP: 4.4.4.4)", response.msg());
+        assertEquals("Your IP address is blocked. Reason: not allowed (Your IP: 4.4.4.4)", response.msg());
         assertEquals(403, response.status());
     }
 


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed blocked outbound default message to 'an outbound connection'.
* Replaced IP block message 'not in allowlist' with 'not allowed'.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104575022?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->