### PR TITLE
Add a java version check for 17 <= and < 25

### DIFF
--- a/agent/src/main/java/dev/aikido/agent/Agent.java
+++ b/agent/src/main/java/dev/aikido/agent/Agent.java
@@ -31,7 +31,7 @@ public class Agent {
             logger.error("Zen by Aikido requires Java 17 or newer. Current version: %d. The agent will not be loaded.", javaVersion);
             return;
         }
-        if (javaVersion >= 25) {
+        if (javaVersion > 24) {
             logger.error("Zen by Aikido does not support Java %d (max supported version: 24). The agent will not be loaded.", javaVersion);
             return;
         }

--- a/agent/src/main/java/dev/aikido/agent/Agent.java
+++ b/agent/src/main/java/dev/aikido/agent/Agent.java
@@ -26,6 +26,15 @@ public class Agent {
         if (new BooleanEnv("AIKIDO_DISABLE", /*default value*/ false).getValue()) {
             return; // AIKIDO_DISABLE is true, so we will not be wrapping anything.
         }
+        int javaVersion = Runtime.version().feature();
+        if (javaVersion < 17) {
+            logger.error("Zen by Aikido requires Java 17 or newer. Current version: %d. The agent will not be loaded.", javaVersion);
+            return;
+        }
+        if (javaVersion >= 25) {
+            logger.error("Zen by Aikido does not support Java %d (max supported version: 24). The agent will not be loaded.", javaVersion);
+            return;
+        }
         logger.info("Zen by Aikido v%s starting.", Config.pkgVersion);
         setAikidoSysProperties();
 


### PR DESCRIPTION
Addresses part of issue https://github.com/AikidoSec/firewall-java/issues/276

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added Java version check to prevent loading on unsupported JVMs.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109484088?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->