### PR TITLE
Databases: only spin up the ones needed to avoid too much pulling

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,7 +57,7 @@ jobs:
           docker run --name mock_core -d -p 5000:5000 mock_core
       - name: Start databases
         working-directory: ./sample-apps/databases
-        run: docker compose up --build -d
+        run: docker compose up --build -d postgres_database
 
       - name: Build Application (ensures cache)
         working-directory: ./sample-apps/${{ matrix.app }}

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -39,16 +39,16 @@ jobs:
     strategy:
       matrix:
         app:
-          - { name: SpringBootPostgres, test_file: end2end/spring_boot_postgres.py }
-          - { name: SpringBootMySQL, test_file: end2end/spring_boot_mysql.py }
-          - { name: SpringBootMSSQL, test_file: end2end/spring_boot_mssql.py }
-          - { name: SpringWebfluxSampleApp, test_file: end2end/spring_webflux_postgres.py }
-          - { name: SpringMVCPostgresKotlin, test_file: end2end/spring_mvc_postgres_kotlin.py }
-          - { name: SpringMVCPostgresGroovy, test_file: end2end/spring_mvc_postgres_groovy.py }
-          - { name: JavalinPostgres, test_file: end2end/javalin_postgres.py }
-          - { name: JavalinMySQLKotlin, test_file: end2end/javalin_mysql_kotlin.py }
-          - { name: SpringBoot2.7Postgres, test_file: end2end/spring_boot_2.7_postgres.py }
-          - { name: SpringBootHyperSQL, test_file: end2end/spring_boot_hypersql.py }
+          - { name: SpringBootPostgres, test_file: end2end/spring_boot_postgres.py, db: postgres_database }
+          - { name: SpringBootMySQL, test_file: end2end/spring_boot_mysql.py, db: mysql_database }
+          - { name: SpringBootMSSQL, test_file: end2end/spring_boot_mssql.py, db: mssql_database }
+          - { name: SpringWebfluxSampleApp, test_file: end2end/spring_webflux_postgres.py, db: postgres_database }
+          - { name: SpringMVCPostgresKotlin, test_file: end2end/spring_mvc_postgres_kotlin.py, db: postgres_database }
+          - { name: SpringMVCPostgresGroovy, test_file: end2end/spring_mvc_postgres_groovy.py, db: postgres_database }
+          - { name: JavalinPostgres, test_file: end2end/javalin_postgres.py, db: postgres_database }
+          - { name: JavalinMySQLKotlin, test_file: end2end/javalin_mysql_kotlin.py, db: mysql_database }
+          - { name: SpringBoot2.7Postgres, test_file: end2end/spring_boot_2.7_postgres.py, db: postgres_database }
+          - { name: SpringBootHyperSQL, test_file: end2end/spring_boot_hypersql.py, db: "" }
         java-version: [17, 18, 19, 20, 21]
         distribution: ['adopt', 'corretto', 'oracle']
     steps:
@@ -69,10 +69,11 @@ jobs:
           docker build -t mock_core .
           docker run --name mock_core -d -p 5000:5000 mock_core
       - name: Start databases
+        if: matrix.app.db != ''
         working-directory: ./sample-apps/databases
         run: |
           docker compose down --volumes
-          docker compose up --build -d
+          docker compose up --build -d ${{ matrix.app.db }}
       - name: Install Python dependencies
         run: python -m pip install -r end2end/requirements.txt
 

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Start databases
         working-directory: ./sample-apps/databases
-        run: docker compose up --build -d && sleep 10
+        run: docker compose up --build -d postgres_database mysql_database mssql_database && sleep 10
 
       - name: Start mock server
         working-directory: ./end2end/server

--- a/.github/workflows/opentel.yml
+++ b/.github/workflows/opentel.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./sample-apps/databases
         run: |
           docker compose down --volumes
-          docker compose up --build -d
+          docker compose up --build -d postgres_database
       - name: Install Python dependencies
         run: python -m pip install -r end2end/requirements.txt
       - name: Cleanup application

--- a/.github/workflows/test-ddtrace.yml
+++ b/.github/workflows/test-ddtrace.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./sample-apps/databases
         run: |
           docker compose down --volumes
-          docker compose up --build -d
+          docker compose up --build -d postgres_database
       - name: Install Python dependencies
         run: python -m pip install -r end2end/requirements.txt
       - name: Cleanup application

--- a/sample-apps/databases/mssql_database/Dockerfile
+++ b/sample-apps/databases/mssql_database/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/mssql/server:2019-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest
 USER root
 
 COPY setup.sql ./setup.sql


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Started only postgres, mysql and mssql databases in CI.
* Added db matrix entries and conditionally started specific databases.
* Restricted test-ddtrace job to start only postgres database.
* Restricted opentel job to start only postgres database.
* Restricted benchmarks job to start only postgres database.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109498211?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->