### PR TITLE
Make release.yml trigger a tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,32 +1,37 @@
 name: 📦 Publish new Release
 
 on:
-  release:
-    types: [created]
-
-permissions:
-  contents: write
-  packages: write
-  deployments: write
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  create-release-asset:
-    runs-on: open-source-releaser
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
 
+  build:
+    needs: extract-version
+    runs-on: open-source-releaser
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set the version for this release
-        run: |
-          TAG_NAME=${GITHUB_REF##*/}
-          make replace_version version=${TAG_NAME#v}
+        run: make replace_version version=${{ needs.extract-version.outputs.version }}
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'adopt'
       - name: Download binaries & Build with Gradle
-        working-directory: ./
         run: chmod +x gradlew && make binaries && make build
       - name: Create zip and tar.gz files of the build
         run: |
@@ -37,43 +42,36 @@ jobs:
         run: |
           shasum -a 256 zen.zip > zen.zip.sha256sum
           shasum -a 256 zen.tar.gz > zen.tar.gz.sha256sum
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./zen.zip
-          asset_name: zen.zip
-          asset_content_type: application/zip
-      - name: Upload Release Asset (SHA)
-        uses: actions/upload-release-asset@v1
+          name: release-artifacts
+          path: |
+            zen.zip
+            zen.zip.sha256sum
+            zen.tar.gz
+            zen.tar.gz.sha256sum
+
+  release:
+    needs: [extract-version, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          draft: true
+          files: |
+            zen.zip
+            zen.zip.sha256sum
+            zen.tar.gz
+            zen.tar.gz.sha256sum
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./zen.zip.sha256sum
-          asset_name: zen.zip.sha256sum
-          asset_content_type: text/plain
-      - name: Upload Release Asset (tar.gz)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./zen.tar.gz
-          asset_name: zen.tar.gz
-          asset_content_type: application/gzip
-      - name: Upload Release Asset (tar.gz SHA)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./zen.tar.gz.sha256sum
-          asset_name: zen.tar.gz.sha256sum
-          asset_content_type: text/plain
-      - name: Publish release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ github.event.release.tag_name }} --draft=false --repo ${{ github.repository }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,5 @@
 # Releasing
 
-1. Go to **GitHub → Releases → Draft a new release**
-2. Choose a tag (e.g. `v1.2.3`) and set it as a **draft**
-3. Click **Save draft** — this triggers the release workflow
-4. The workflow builds the artifacts, uploads them to the draft, then publishes the release automatically
+1. Create and push a tag for the version you want to release (e.g. `git tag v1.2.3 && git push origin v1.2.3`) — this triggers the release workflow
+2. The workflow builds the artifacts and uploads them to a **draft** release on GitHub
+3. Go to **GitHub → Releases**, review the draft, then click **Edit → Publish release** to make it public


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled workflow to trigger on tag pushes matching v* patterns.
* Added extract-version job to parse tag and expose version output.

**🔧 Refactors**
* Reworked build and release jobs, upgraded actions, and artifact handling.

**📚 Documentation**
* Updated RELEASE.md to instruct creating and pushing a version tag.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111804127?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->