### PR TITLE
Change runner from ubuntu-latest to open-source-releaser for the release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
   release:
     needs: [extract-version, build]
-    runs-on: ubuntu-latest
+    runs-on: open-source-releaser
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched CI workflow runners from ubuntu-latest to open-source-releaser


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112688885?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->