### PR TITLE
Trim user input before sending to detectSqlInjection

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/SqlDetector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/sql_injection/SqlDetector.java
@@ -35,11 +35,11 @@ public class SqlDetector implements Detector {
     }
     public static boolean detectSqlInjection(String query, String userInput, Dialect dialect) {
         String queryLower = query.toLowerCase();
-        String userInputLower = userInput.toLowerCase();
-        if (shouldReturnEarly(queryLower, userInputLower)) {
+        String userInputNormalized = userInput.toLowerCase().trim();
+        if (shouldReturnEarly(queryLower, userInputNormalized)) {
             return false;
         }
-        return RustSQLInterface.detectSqlInjection(queryLower, userInputLower, dialect);
+        return RustSQLInterface.detectSqlInjection(queryLower, userInputNormalized, dialect);
     }
     /**
      *     Input : Lowercased query and user_input.

--- a/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
+++ b/agent_api/src/test/java/vulnerabilities/SqlInjectionTest.java
@@ -357,6 +357,17 @@ public class SqlInjectionTest {
         );
     }
     @Test
+    public void testTrimmedUserInputBypass() {
+        // Attacker pads payload with trailing spaces; app trims before DB execution.
+        // The trimmed payload must still be detected (AIKIDO-OR0E0082).
+        isSqlInjection(
+                "INSERT INTO pets (name, owner) VALUES ('x', 'dummy'), ('injected', 'hacker'); --', 'owner')",
+                "x', 'dummy'), ('injected', 'hacker'); --    ",
+                "all"
+        );
+    }
+
+    @Test
     public void testLowercasedInputSqlInjection() {
         String sql = """
         SELECT id,


### PR DESCRIPTION
<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Trimmed and normalized user input before SQL injection detection call


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124558019?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->