### PR TITLE
Make path traversal containment check case-insensitive

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/path_traversal/PathTraversalDetector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/path_traversal/PathTraversalDetector.java
@@ -30,7 +30,7 @@ public class PathTraversalDetector implements Detector {
             // Ignore cases where the user input is longer than the file path.
             return new DetectorResult();
         }
-        if (!filePath.contains(userInput)) {
+        if (!filePath.toLowerCase().contains(userInput.toLowerCase())) {
             // Ignore cases where the user input is not part of the file path.
             return new DetectorResult();
         }

--- a/agent_api/src/test/java/vulnerabilities/path_traversal/PathTraversalDetectorTest.java
+++ b/agent_api/src/test/java/vulnerabilities/path_traversal/PathTraversalDetectorTest.java
@@ -210,4 +210,11 @@ public class PathTraversalDetectorTest {
     public void testUserInputWithFilePathContainingSpaces() {
         assertNotAttack(PathTraversalDetector.INSTANCE.run("test file", new String[]{"directory/test file.txt"}));
     }
+
+    @Test
+    public void testCaseInsensitiveContainmentDetectsTraversal() {
+        assertAttack(PathTraversalDetector.INSTANCE.run("/ETC/passwd", new String[]{"/etc/passwd"}));
+        assertAttack(PathTraversalDetector.INSTANCE.run("/ETC/PASSWD", new String[]{"/etc/passwd"}));
+        assertAttack(PathTraversalDetector.INSTANCE.run("/HOME/USER/file.txt", new String[]{"/home/user/file.txt"}));
+    }
 }


### PR DESCRIPTION
Makes the user-input containment check in path traversal detection case-insensitive, matching the fix applied to the Node.js firewall in AikidoSec/firewall-node#1047.

**Problem**: On case-insensitive filesystems (macOS APFS, Windows NTFS), an attacker can submit a path like `/ETC/PASSWD` which resolves to `/etc/passwd`. The detection check `filePath.contains(userInput)` was case-sensitive, so `/ETC/PASSWD` would not be found in `/etc/passwd` and traversal would go undetected.

**Fix**: Changed `filePath.contains(userInput)` to `filePath.toLowerCase().contains(userInput.toLowerCase())`. Note that `startsWithUnsafePath` already lowercases both sides before comparing, so no change was needed there.

See: https://github.com/AikidoSec/firewall-node/pull/1047

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Made path containment check case-insensitive to fix traversal detection


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124652853?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->