### PR TITLE
Count 404 requests with foreign extensions as attack wave scans

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/WebResponseCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/WebResponseCollector.java
@@ -29,7 +29,7 @@ public final class WebResponseCollector {
         }
 
         // Check for attack waves
-        if (AttackWaveDetectorStore.check(context)) {
+        if (AttackWaveDetectorStore.check(context, statusCode)) {
             AttackQueue.add(
                 DetectedAttackWave.createAPIEvent(context)
             );

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/attack_wave_detector/AttackWaveDetector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/attack_wave_detector/AttackWaveDetector.java
@@ -44,10 +44,11 @@ public class AttackWaveDetector {
     /**
      * Checks if the request is part of an attack wave.
      *
-     * @param ctx the context object to check.
+     * @param ctx        the context object to check.
+     * @param statusCode the HTTP response status code.
      * @return true if an attack wave is detected and should be reported.
      */
-    public boolean check(ContextObject ctx) {
+    public boolean check(ContextObject ctx, int statusCode) {
         String ip = ctx.getRemoteAddress();
         if (ip == null) {
             return false;
@@ -59,7 +60,7 @@ public class AttackWaveDetector {
             return false;
         }
 
-        if (!isWebScanner(ctx)) {
+        if (!isWebScanner(ctx, statusCode)) {
             return false;
         }
 

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/attack_wave_detector/AttackWaveDetectorStore.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/attack_wave_detector/AttackWaveDetectorStore.java
@@ -15,10 +15,10 @@ public final class AttackWaveDetectorStore {
     private AttackWaveDetectorStore() {
     }
 
-    public static boolean check(ContextObject ctx) {
+    public static boolean check(ContextObject ctx, int statusCode) {
         mutex.lock();
         try {
-            return detector.check(ctx);
+            return detector.check(ctx, statusCode);
         } catch (Throwable e) {
             logger.debug("An error occurred checking for attack waves: %s", e.getMessage());
             return false;

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/attack_wave_detection/PathChecker.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/attack_wave_detection/PathChecker.java
@@ -2,6 +2,8 @@ package dev.aikido.agent_api.vulnerabilities.attack_wave_detection;
 
 import dev.aikido.agent_api.helpers.ArrayHelpers;
 
+import java.util.Set;
+
 import static dev.aikido.agent_api.helpers.ArrayHelpers.containsIgnoreCase;
 import static dev.aikido.agent_api.vulnerabilities.attack_wave_detection.Paths.*;
 
@@ -9,7 +11,12 @@ public final class PathChecker {
     private PathChecker() {
     }
 
-    public static boolean isWebScanPath(String path) {
+    // Extensions that a Java app would not normally serve — only count as scan hits on 404
+    private static final Set<String> FOREIGN_EXTENSIONS = Set.of(
+        "php", "php3", "php4", "php5", "phtml"
+    );
+
+    public static boolean isWebScanPath(String path, int statusCode) {
         String normalized = path.toLowerCase();
         String[] segments = normalized.split("/");
         String filename = ArrayHelpers.lastElement(segments);
@@ -23,6 +30,11 @@ public final class PathChecker {
             if (dotIndex != -1) {
                 String ext = filename.substring(dotIndex + 1);
                 if (containsIgnoreCase(FILE_EXTENSIONS, ext)) {
+                    return true;
+                }
+                // Foreign extensions (e.g. PHP) are only suspicious when the response is 404.
+                // A 200 may mean the Java app is proxying to another backend.
+                if (FOREIGN_EXTENSIONS.contains(ext) && statusCode == 404) {
                     return true;
                 }
             }

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/attack_wave_detection/WebScanDetector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/attack_wave_detection/WebScanDetector.java
@@ -9,14 +9,14 @@ import static dev.aikido.agent_api.vulnerabilities.attack_wave_detection.PathChe
 public final class WebScanDetector {
     private WebScanDetector() {}
 
-    public static boolean isWebScanner(ContextObject ctx) {
+    public static boolean isWebScanner(ContextObject ctx, int statusCode) {
         String method = ctx.getMethod();
         if (method != null && isWebScanMethod(method)) {
             return true;
         }
 
         String route = ctx.getRoute();
-        if (route != null && isWebScanPath(route)) {
+        if (route != null && isWebScanPath(route, statusCode)) {
             return true;
         }
 

--- a/agent_api/src/test/java/attack_wave_detection/AttackWaveDetectorTest.java
+++ b/agent_api/src/test/java/attack_wave_detection/AttackWaveDetectorTest.java
@@ -21,7 +21,7 @@ class AttackWaveDetectorTest {
             ctx = new EmptySampleContextObject("../etc/passwd", "/wp-config.php", "BADMETHOD");
         }
         ctx.setIp(ip);
-        return detector.check(ctx);
+        return detector.check(ctx, 404);
     }
 
     @Test
@@ -129,13 +129,13 @@ class AttackWaveDetectorTest {
     @Test
     void testItRespectsSamplesLimit() {
         AttackWaveDetector detector = newAttackWaveDetector();
-        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "GET"));
-        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "GET"));
-        detector.check(new EmptySampleContextObject("", "/test2", "GET"));
-        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "POST"));
-        detector.check(new EmptySampleContextObject("", "/test3", "PUT"));
-        detector.check(new EmptySampleContextObject("", "/.env", "GET"));
-        detector.check(new EmptySampleContextObject("", "/test4", "BADMETHOD"));
+        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "GET"), 404);
+        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "GET"), 404);
+        detector.check(new EmptySampleContextObject("", "/test2", "GET"), 404);
+        detector.check(new EmptySampleContextObject("", "/../etc/passwd", "POST"), 404);
+        detector.check(new EmptySampleContextObject("", "/test3", "PUT"), 404);
+        detector.check(new EmptySampleContextObject("", "/.env", "GET"), 404);
+        detector.check(new EmptySampleContextObject("", "/test4", "BADMETHOD"), 404);
         assertArrayEquals(
             List.of(
                 new AttackWaveDetector.Sample("GET", "https://example.com/../etc/passwd"),

--- a/agent_api/src/test/java/attack_wave_detection/PathCheckerTest.java
+++ b/agent_api/src/test/java/attack_wave_detection/PathCheckerTest.java
@@ -18,7 +18,7 @@ public class PathCheckerTest {
         };
         for (String path : dangerousPaths) {
             assertTrue(
-                isWebScanPath(path),
+                isWebScanPath(path, 404),
                 "Expected '" + path + "' to be detected as a web scan path"
             );
         }
@@ -32,9 +32,33 @@ public class PathCheckerTest {
         };
         for (String path : safePaths) {
             assertFalse(
-                isWebScanPath(path),
+                isWebScanPath(path, 404),
                 "Expected '" + path + "' to NOT be detected as a web scan path"
             );
         }
+    }
+
+    @Test
+    void testForeignExtensions_404_ReturnsTrue() {
+        assertTrue(isWebScanPath("/admin.php", 404),
+            "php extension with 404 should be a scan path");
+        assertTrue(isWebScanPath("/config.php5", 404),
+            "php5 extension with 404 should be a scan path");
+        assertTrue(isWebScanPath("/index.php3", 404),
+            "php3 extension with 404 should be a scan path");
+        assertTrue(isWebScanPath("/index.php4", 404),
+            "php4 extension with 404 should be a scan path");
+        assertTrue(isWebScanPath("/page.phtml", 404),
+            "phtml extension with 404 should be a scan path");
+    }
+
+    @Test
+    void testForeignExtensions_200_ReturnsFalse() {
+        assertFalse(isWebScanPath("/admin.php", 200),
+            "php extension with 200 should NOT be a scan path (app may proxy to PHP backend)");
+        assertFalse(isWebScanPath("/config.php5", 200),
+            "php5 extension with 200 should NOT be a scan path");
+        assertFalse(isWebScanPath("/page.phtml", 200),
+            "phtml extension with 200 should NOT be a scan path");
     }
 }

--- a/agent_api/src/test/java/attack_wave_detection/WebScanDetectorBenchmarkTest.java
+++ b/agent_api/src/test/java/attack_wave_detection/WebScanDetectorBenchmarkTest.java
@@ -19,9 +19,9 @@ class WebScanDetectorBenchmarkTest {
         int iterations = 25_000;
         long start = System.nanoTime();
         for (int i = 0; i < iterations; i++) {
-            WebScanDetector.isWebScanner(getTestContext("/wp-config.php", "GET", "1"));
-            WebScanDetector.isWebScanner(getTestContext("/vulnerable", "GET", "1'; DROP TABLE users; --"));
-            WebScanDetector.isWebScanner(getTestContext("/", "GET", "1"));
+            WebScanDetector.isWebScanner(getTestContext("/wp-config.php", "GET", "1"), 404);
+            WebScanDetector.isWebScanner(getTestContext("/vulnerable", "GET", "1'; DROP TABLE users; --"), 200);
+            WebScanDetector.isWebScanner(getTestContext("/", "GET", "1"), 200);
         }
         long end = System.nanoTime();
         double timePerCheck = (double) (end - start) / iterations / 3 / 1_000_000; // Convert nanoseconds to milliseconds

--- a/agent_api/src/test/java/attack_wave_detection/WebScanDetectorTest.java
+++ b/agent_api/src/test/java/attack_wave_detection/WebScanDetectorTest.java
@@ -20,48 +20,48 @@ public class WebScanDetectorTest {
     @Test
     public void testIsWebScanner_PositiveCases() {
         // Test suspicious paths
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/wp-config.php", "GET", Map.of())));
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.env", "GET", Map.of())));
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/test/.env.bak", "GET", Map.of())));
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.git/config", "GET", Map.of())));
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.aws/config", "GET", Map.of())));
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/../secret", "GET", Map.of())));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/wp-config.php", "GET", Map.of()), 404));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.env", "GET", Map.of()), 404));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/test/.env.bak", "GET", Map.of()), 404));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.git/config", "GET", Map.of()), 404));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/.aws/config", "GET", Map.of()), 404));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/../secret", "GET", Map.of()), 404));
 
         // Test suspicious method
-        assertTrue(WebScanDetector.isWebScanner(createTestContext("/", "BADMETHOD", Map.of())));
+        assertTrue(WebScanDetector.isWebScanner(createTestContext("/", "BADMETHOD", Map.of()), 200));
 
         // Test suspicious query parameters
         assertTrue(WebScanDetector.isWebScanner(
-            createTestContext("/", "GET", Map.of("test", List.of("SELECT * FROM admin")))
+            createTestContext("/", "GET", Map.of("test", List.of("SELECT * FROM admin"))), 200
         ));
         assertTrue(WebScanDetector.isWebScanner(
-            createTestContext("/", "GET", Map.of("test", List.of("../etc/passwd")))
+            createTestContext("/", "GET", Map.of("test", List.of("../etc/passwd"))), 200
         ));
     }
 
     @Test
     public void testIsWebScanner_NegativeCases() {
         // Test safe paths
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", "POST", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("/api/v1/users", "GET", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("/public/index.html", "GET", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("/static/js/app.js", "GET", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("/uploads/image.png", "GET", Map.of())));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", "POST", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("/api/v1/users", "GET", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("/public/index.html", "GET", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("/static/js/app.js", "GET", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("/uploads/image.png", "GET", Map.of()), 200));
 
         // Test safe query parameters
         assertFalse(WebScanDetector.isWebScanner(
-            createTestContext("/", "GET", Map.of("test", List.of("1'")))
+            createTestContext("/", "GET", Map.of("test", List.of("1'"))), 200
         ));
         assertFalse(WebScanDetector.isWebScanner(
-            createTestContext("/", "GET", Map.of("test", List.of("abcd")))
+            createTestContext("/", "GET", Map.of("test", List.of("abcd"))), 200
         ));
     }
 
     @Test
     public void testWithNull() {
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", "POST", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext(null, "POST", Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", null, Map.of())));
-        assertFalse(WebScanDetector.isWebScanner(createTestContext(null, null, Map.of())));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", "POST", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext(null, "POST", Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext("graphql", null, Map.of()), 200));
+        assertFalse(WebScanDetector.isWebScanner(createTestContext(null, null, Map.of()), 200));
     }
 }


### PR DESCRIPTION
## Summary

Ports [AikidoSec/firewall-node#1041](https://github.com/AikidoSec/firewall-node/issues/1041) to Java.

- Requests to foreign-platform extensions (`php`, `php3`, `php4`, `php5`, `phtml`) are only counted as attack wave scan hits when the HTTP response is 404
- A 200 response may indicate the Java app is proxying to a PHP backend — those should not be flagged
- `jsp`/`jspx` are intentionally excluded since Java apps can legitimately serve JSP files

## Changes

- `PathChecker`: added `FOREIGN_EXTENSIONS` set; `isWebScanPath(String)` → `isWebScanPath(String, int statusCode)` with the new 404-gated check
- `WebScanDetector`: `isWebScanner(ctx)` → `isWebScanner(ctx, statusCode)`, threads `statusCode` to `isWebScanPath`
- `AttackWaveDetector` / `AttackWaveDetectorStore`: `check(ctx)` → `check(ctx, statusCode)`, threads `statusCode` to `isWebScanner`
- `WebResponseCollector`: passes the already-available `statusCode` parameter to `AttackWaveDetectorStore.check`

## Test plan

- [ ] `PathCheckerTest.testForeignExtensions_404_ReturnsTrue` — php/php3/php4/php5/phtml with 404 → `true`
- [ ] `PathCheckerTest.testForeignExtensions_200_ReturnsFalse` — same extensions with 200 → `false`
- [ ] All existing `PathCheckerTest`, `WebScanDetectorTest`, `AttackWaveDetectorTest`, and benchmark tests pass with updated signatures
- [ ] `./gradlew :agent_api:test` passes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Treated foreign-platform extensions as scans only when response was 404


<sup>[More info](https://app.aikido.dev/featurebranch/scan/124658030?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->