### PR TITLE
Trim trailing dot from trusted IMDS hostnames

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/NormalizeHostname.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/NormalizeHostname.java
@@ -1,0 +1,25 @@
+package dev.aikido.agent_api.helpers.net;
+
+import java.net.IDN;
+
+public final class NormalizeHostname {
+    private NormalizeHostname() {}
+
+    /**
+     * Canonicalizes a hostname for consistent comparison: lowercases, strips a
+     * trailing dot (FQDN form returned by some DNS resolvers), and converts
+     * Punycode labels to Unicode via IDN.
+     */
+    public static String normalize(String hostname) {
+        if (hostname == null || hostname.isEmpty()) {
+            return hostname;
+        }
+        String lower = hostname.toLowerCase();
+        String noDot = lower.endsWith(".") ? lower.substring(0, lower.length() - 1) : lower;
+        try {
+            return IDN.toUnicode(noDot);
+        } catch (Exception e) {
+            return noDot;
+        }
+    }
+}

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/ssrf/imds/TrustedHosts.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/ssrf/imds/TrustedHosts.java
@@ -1,8 +1,7 @@
 package dev.aikido.agent_api.vulnerabilities.ssrf.imds;
 
+import dev.aikido.agent_api.helpers.net.NormalizeHostname;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 public final class TrustedHosts {
     private TrustedHosts() {}
@@ -13,10 +12,6 @@ public final class TrustedHosts {
 
     /** Checks if this hostname is trusted */
     public static boolean isTrustedHostname(String hostname) {
-        String normalized = hostname.toLowerCase();
-        if (normalized.endsWith(".")) {
-            normalized = normalized.substring(0, normalized.length() - 1);
-        }
-        return Arrays.asList(trustedHosts).contains(normalized);
+        return Arrays.asList(trustedHosts).contains(NormalizeHostname.normalize(hostname));
     }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/ssrf/imds/TrustedHosts.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/vulnerabilities/ssrf/imds/TrustedHosts.java
@@ -13,6 +13,10 @@ public final class TrustedHosts {
 
     /** Checks if this hostname is trusted */
     public static boolean isTrustedHostname(String hostname) {
-        return Arrays.asList(trustedHosts).contains(hostname);
+        String normalized = hostname.toLowerCase();
+        if (normalized.endsWith(".")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return Arrays.asList(trustedHosts).contains(normalized);
     }
 }

--- a/agent_api/src/test/java/helpers/net/NormalizeHostnameTest.java
+++ b/agent_api/src/test/java/helpers/net/NormalizeHostnameTest.java
@@ -1,0 +1,40 @@
+package helpers.net;
+
+import dev.aikido.agent_api.helpers.net.NormalizeHostname;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class NormalizeHostnameTest {
+
+    @Test
+    void testNullAndEmpty() {
+        assertNull(NormalizeHostname.normalize(null));
+        assertEquals("", NormalizeHostname.normalize(""));
+    }
+
+    @Test
+    void testLowercases() {
+        assertEquals("example.com", NormalizeHostname.normalize("EXAMPLE.COM"));
+        assertEquals("metadata.google.internal", NormalizeHostname.normalize("METADATA.GOOGLE.INTERNAL"));
+    }
+
+    @Test
+    void testStripsTrailingDot() {
+        assertEquals("example.com", NormalizeHostname.normalize("example.com."));
+        assertEquals("metadata.google.internal", NormalizeHostname.normalize("metadata.google.internal."));
+        assertEquals("metadata.goog", NormalizeHostname.normalize("metadata.goog."));
+    }
+
+    @Test
+    void testStripsTrailingDotAndLowercases() {
+        assertEquals("metadata.google.internal", NormalizeHostname.normalize("METADATA.GOOGLE.INTERNAL."));
+    }
+
+    @Test
+    void testPlainHostnameUnchanged() {
+        assertEquals("example.com", NormalizeHostname.normalize("example.com"));
+        assertEquals("localhost", NormalizeHostname.normalize("localhost"));
+    }
+}

--- a/agent_api/src/test/java/vulnerabilities/ssrf/ResolverTest.java
+++ b/agent_api/src/test/java/vulnerabilities/ssrf/ResolverTest.java
@@ -85,4 +85,13 @@ public class ResolverTest {
 
         assertNull(Resolver.resolvesToImdsIp(resolvedIps, "metadata.google.internal"));
     }
+
+    @Test
+    void testResolvesToImdsIp_TrustedHostnameWithTrailingDot() {
+        Set<String> resolvedIps = new HashSet<>();
+        resolvedIps.add("169.254.169.254"); // IMDS IP
+
+        assertNull(Resolver.resolvesToImdsIp(resolvedIps, "metadata.google.internal."));
+        assertNull(Resolver.resolvesToImdsIp(resolvedIps, "metadata.goog."));
+    }
 }


### PR DESCRIPTION
## Summary

DNS resolvers sometimes return fully-qualified domain names with a trailing dot (e.g. `metadata.google.internal.`). The previous `Arrays.asList(trustedHosts).contains(hostname)` check in `TrustedHosts.isTrustedHostname` did not normalize the hostname, so trailing-dot forms were not matched and GCP IMDS requests could be incorrectly flagged as stored SSRF.

- Lowercase + strip trailing dot before the contains check
- Add test cases for trailing-dot variants in `ResolverTest`

This is the same fix already applied in firewall-go (PR #459). Ported to Python, Ruby, .NET, PHP, and Java.

## Test plan
- [ ] `./gradlew :agent_api:test --tests "vulnerabilities.ssrf.ResolverTest"` passes

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Normalized hostnames and trimmed trailing dots to fix mismatches

**🔧 Refactors**
* Removed unused imports and replaced inline normalization with helper


<sup>[More info](https://app.aikido.dev/featurebranch/scan/128314208?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->