### PR TITLE
Fix request context propagation for async executor tasks

### DIFF
--- a/agent/src/main/java/dev/aikido/agent/Wrappers.java
+++ b/agent/src/main/java/dev/aikido/agent/Wrappers.java
@@ -1,6 +1,11 @@
 package dev.aikido.agent;
 
 import dev.aikido.agent.wrappers.*;
+import dev.aikido.agent.wrappers.executor.AbstractExecutorServiceWrapper;
+import dev.aikido.agent.wrappers.executor.DelegatedExecutorServiceWrapper;
+import dev.aikido.agent.wrappers.executor.ForkJoinPoolWrapper;
+import dev.aikido.agent.wrappers.executor.ScheduledThreadPoolExecutorWrapper;
+import dev.aikido.agent.wrappers.executor.ThreadPoolExecutorWrapper;
 import dev.aikido.agent.wrappers.file.FileConstructorMultiArgumentWrapper;
 import dev.aikido.agent.wrappers.file.FileConstructorSingleArgumentWrapper;
 import dev.aikido.agent.wrappers.javalin.*;
@@ -17,6 +22,13 @@ public final class Wrappers {
     private Wrappers() {}
     public static final List<Wrapper> WRAPPERS = Arrays.asList(
             new PostgresWrapper(),
+
+            new DelegatedExecutorServiceWrapper(),
+            new ThreadPoolExecutorWrapper(),
+            new AbstractExecutorServiceWrapper(),
+            new ForkJoinPoolWrapper(),
+            new ScheduledThreadPoolExecutorWrapper(),
+
             new SpringMVCJakartaWrapper(),
             new SpringMVCJavaxWrapper(),
             new SpringWebfluxWrapper(),

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/AbstractExecutorServiceWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/AbstractExecutorServiceWrapper.java
@@ -1,0 +1,52 @@
+package dev.aikido.agent.wrappers.executor;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Callable;
+
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class AbstractExecutorServiceWrapper implements Wrapper {
+    @Override
+    public String getName() {
+        return SubmitAdvice.class.getName();
+    }
+
+    @Override
+    public ElementMatcher getMatcher() {
+        return isMethod()
+            .and(named("submit"))
+            .and(
+                takesArguments(Runnable.class)
+                    .or(takesArguments(Callable.class))
+                    .or(takesArguments(Runnable.class, Object.class))
+            );
+    }
+
+    @Override
+    public ElementMatcher getTypeMatcher() {
+        return isSubTypeOf(AbstractExecutorService.class);
+    }
+
+    public static class SubmitAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+            @Advice.Argument(value = 0, readOnly = false, typing = DYNAMIC) Object task
+        ) {
+            if (task instanceof Runnable) {
+                task = ExecutorContextPropagation.wrap((Runnable) task);
+            } else if (task instanceof Callable) {
+                task = ExecutorContextPropagation.wrap((Callable) task);
+            }
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/DelegatedExecutorServiceWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/DelegatedExecutorServiceWrapper.java
@@ -1,0 +1,72 @@
+package dev.aikido.agent.wrappers.executor;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.Callable;
+
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class DelegatedExecutorServiceWrapper implements Wrapper {
+    @Override
+    public String getName() {
+        return DelegatedExecutorAdvice.class.getName();
+    }
+
+    @Override
+    public ElementMatcher getMatcher() {
+        return isMethod()
+            .and(named("execute").or(named("submit")))
+            .and(
+                takesArguments(Runnable.class)
+                    .or(takesArguments(Callable.class))
+                    .or(takesArguments(Runnable.class, Object.class))
+            );
+    }
+
+    @Override
+    public ElementMatcher getTypeMatcher() {
+        return nameStartsWith("java.util.concurrent.Executors$");
+    }
+
+    public static class DelegatedExecutorAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+            @Advice.Argument(value = 0, readOnly = false, typing = DYNAMIC) Object task
+        ) throws Exception {
+            if (task == null) {
+                return;
+            }
+
+            // This advice is applied to JDK classes loaded by the bootstrap classloader.
+            // Load agent_api reflectively because bootstrap classes cannot directly reference agent classes.
+            String jarFilePath = System.getProperty("AIK_agent_api_jar");
+            if (jarFilePath == null || jarFilePath.isBlank()) {
+                return;
+            }
+
+            URLClassLoader classLoader = new URLClassLoader(new URL[] { new URL(jarFilePath) });
+            Class<?> contextPropagationClass = classLoader.loadClass(
+                "dev.aikido.agent_api.context.ContextPropagation"
+            );
+
+            if (task instanceof Runnable) {
+                Method wrapRunnable = contextPropagationClass.getMethod("wrap", Runnable.class);
+                task = wrapRunnable.invoke(null, task);
+            } else if (task instanceof Callable) {
+                Method wrapCallable = contextPropagationClass.getMethod("wrap", Callable.class);
+                task = wrapCallable.invoke(null, task);
+            }
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/ExecutorContextPropagation.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/ExecutorContextPropagation.java
@@ -1,0 +1,76 @@
+package dev.aikido.agent.wrappers.executor;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.Callable;
+
+// Bridges the executor advice (woven into java.util.concurrent classes) to ContextPropagation in
+// agent_api, which lives on a different classloader, and caches the reflected methods so the lookup
+// happens once. A missing AIK_agent_api_jar is treated as "not ready yet" (early startup) and
+// retried on the next call, rather than disabling propagation for the whole JVM; only a genuine
+// load failure once the path is set disables it.
+public final class ExecutorContextPropagation {
+    private static volatile Method wrapRunnableMethod;
+    private static volatile Method wrapCallableMethod;
+    private static volatile boolean disabled;
+
+    private ExecutorContextPropagation() {}
+
+    public static Runnable wrap(Runnable task) {
+        if (task == null) {
+            return task;
+        }
+        Method wrap = wrapRunnableMethod;
+        if (wrap == null) {
+            init();
+            wrap = wrapRunnableMethod;
+        }
+        if (wrap == null) {
+            return task;
+        }
+        try {
+            return (Runnable) wrap.invoke(null, task);
+        } catch (Throwable ignored) {
+            return task;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Callable<T> wrap(Callable<T> task) {
+        if (task == null) {
+            return task;
+        }
+        Method wrap = wrapCallableMethod;
+        if (wrap == null) {
+            init();
+            wrap = wrapCallableMethod;
+        }
+        if (wrap == null) {
+            return task;
+        }
+        try {
+            return (Callable<T>) wrap.invoke(null, task);
+        } catch (Throwable ignored) {
+            return task;
+        }
+    }
+
+    private static synchronized void init() {
+        if (disabled || wrapRunnableMethod != null) {
+            return;
+        }
+        String jarFilePath = System.getProperty("AIK_agent_api_jar");
+        if (jarFilePath == null || jarFilePath.isBlank()) {
+            return; // not set yet during early startup - retry on a later call
+        }
+        try {
+            URLClassLoader classLoader = new URLClassLoader(new URL[] { new URL(jarFilePath) });
+            Class<?> clazz = classLoader.loadClass("dev.aikido.agent_api.context.ContextPropagation");
+            wrapCallableMethod = clazz.getMethod("wrap", Callable.class);
+            wrapRunnableMethod = clazz.getMethod("wrap", Runnable.class);
+        } catch (Throwable ignored) {
+            disabled = true;
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/ForkJoinPoolWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/ForkJoinPoolWrapper.java
@@ -1,0 +1,52 @@
+package dev.aikido.agent.wrappers.executor;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class ForkJoinPoolWrapper implements Wrapper {
+    @Override
+    public String getName() {
+        return ForkJoinAdvice.class.getName();
+    }
+
+    @Override
+    public ElementMatcher getMatcher() {
+        return isMethod()
+            .and(named("execute").or(named("submit")))
+            .and(
+                takesArguments(Runnable.class)
+                    .or(takesArguments(Callable.class))
+                    .or(takesArguments(Runnable.class, Object.class))
+            );
+    }
+
+    @Override
+    public ElementMatcher getTypeMatcher() {
+        return isSubTypeOf(ForkJoinPool.class);
+    }
+
+    public static class ForkJoinAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+            @Advice.Argument(value = 0, readOnly = false, typing = DYNAMIC) Object task
+        ) {
+            if (task instanceof Runnable) {
+                task = ExecutorContextPropagation.wrap((Runnable) task);
+            } else if (task instanceof Callable) {
+                task = ExecutorContextPropagation.wrap((Callable) task);
+            }
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/ScheduledThreadPoolExecutorWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/ScheduledThreadPoolExecutorWrapper.java
@@ -1,0 +1,73 @@
+package dev.aikido.agent.wrappers.executor;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class ScheduledThreadPoolExecutorWrapper implements Wrapper {
+    @Override
+    public String getName() {
+        return ScheduleAdvice.class.getName();
+    }
+
+    @Override
+    public ElementMatcher getMatcher() {
+        return isMethod()
+            .and(named("schedule"))
+            .and(
+                takesArguments(Runnable.class, long.class, TimeUnit.class)
+                    .or(takesArguments(Callable.class, long.class, TimeUnit.class))
+            );
+    }
+
+    @Override
+    public ElementMatcher getTypeMatcher() {
+        return isSubTypeOf(ScheduledThreadPoolExecutor.class);
+    }
+
+    public static class ScheduleAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+            @Advice.Argument(value = 0, readOnly = false, typing = DYNAMIC) Object task
+        ) throws Exception {
+            if (task == null) {
+                return;
+            }
+
+            // This advice is applied to JDK classes loaded by the bootstrap classloader.
+            // Load agent_api reflectively because bootstrap classes cannot directly reference agent classes.
+            String jarFilePath = System.getProperty("AIK_agent_api_jar");
+            if (jarFilePath == null || jarFilePath.isBlank()) {
+                return;
+            }
+
+            URLClassLoader classLoader = new URLClassLoader(new URL[] { new URL(jarFilePath) });
+            Class<?> contextPropagationClass = classLoader.loadClass(
+                "dev.aikido.agent_api.context.ContextPropagation"
+            );
+
+            if (task instanceof Runnable) {
+                Method wrapRunnable = contextPropagationClass.getMethod("wrap", Runnable.class);
+                task = wrapRunnable.invoke(null, task);
+            } else if (task instanceof Callable) {
+                Method wrapCallable = contextPropagationClass.getMethod("wrap", Callable.class);
+                task = wrapCallable.invoke(null, task);
+            }
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/executor/ThreadPoolExecutorWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/executor/ThreadPoolExecutorWrapper.java
@@ -1,0 +1,42 @@
+package dev.aikido.agent.wrappers.executor;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static net.bytebuddy.matcher.ElementMatchers.isMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class ThreadPoolExecutorWrapper implements Wrapper {
+    @Override
+    public String getName() {
+        return ExecuteAdvice.class.getName();
+    }
+
+    @Override
+    public ElementMatcher getMatcher() {
+        return isMethod()
+            .and(named("execute"))
+            .and(takesArguments(Runnable.class));
+    }
+
+    @Override
+    public ElementMatcher getTypeMatcher() {
+        return isSubTypeOf(ThreadPoolExecutor.class);
+    }
+
+    public static class ExecuteAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+            @Advice.Argument(value = 0, readOnly = false) Runnable task
+        ) {
+            task = ExecutorContextPropagation.wrap(task);
+        }
+    }
+}

--- a/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagatingCallable.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagatingCallable.java
@@ -1,0 +1,29 @@
+package dev.aikido.agent_api.context;
+
+import java.util.concurrent.Callable;
+
+public final class ContextPropagatingCallable<T> implements Callable<T> {
+    private final Callable<T> delegate;
+    private final ContextObject context;
+
+    public ContextPropagatingCallable(Callable<T> delegate, ContextObject context) {
+        this.delegate = delegate;
+        this.context = context;
+    }
+
+    @Override
+    public T call() throws Exception {
+        ContextObject previousContext = Context.get();
+
+        try {
+            Context.set(context);
+            return delegate.call();
+        } finally {
+            if (previousContext != null) {
+                Context.set(previousContext);
+            } else {
+                Context.reset();
+            }
+        }
+    }
+}

--- a/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagatingRunnable.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagatingRunnable.java
@@ -1,0 +1,27 @@
+package dev.aikido.agent_api.context;
+
+public final class ContextPropagatingRunnable implements Runnable {
+    private final Runnable delegate;
+    private final ContextObject context;
+
+    public ContextPropagatingRunnable(Runnable delegate, ContextObject context) {
+        this.delegate = delegate;
+        this.context = context;
+    }
+
+    @Override
+    public void run() {
+        ContextObject previousContext = Context.get();
+
+        try {
+            Context.set(context);
+            delegate.run();
+        } finally {
+            if (previousContext != null) {
+                Context.set(previousContext);
+            } else {
+                Context.reset();
+            }
+        }
+    }
+}

--- a/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagation.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/context/ContextPropagation.java
@@ -1,0 +1,33 @@
+package dev.aikido.agent_api.context;
+
+import java.util.concurrent.Callable;
+
+public final class ContextPropagation {
+    private ContextPropagation() {}
+
+    public static Runnable wrap(Runnable task) {
+        if (task == null || task instanceof ContextPropagatingRunnable) {
+            return task;
+        }
+
+        ContextObject context = Context.get();
+        if (context == null) {
+            return task;
+        }
+
+        return new ContextPropagatingRunnable(task, context);
+    }
+
+    public static <T> Callable<T> wrap(Callable<T> task) {
+        if (task == null || task instanceof ContextPropagatingCallable) {
+            return task;
+        }
+
+        ContextObject context = Context.get();
+        if (context == null) {
+            return task;
+        }
+
+        return new ContextPropagatingCallable<>(task, context);
+    }
+}

--- a/agent_api/src/test/java/context/ContextPropagationTest.java
+++ b/agent_api/src/test/java/context/ContextPropagationTest.java
@@ -1,0 +1,224 @@
+package context;
+
+import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.context.ContextObject;
+import dev.aikido.agent_api.context.ContextPropagatingCallable;
+import dev.aikido.agent_api.context.ContextPropagatingRunnable;
+import dev.aikido.agent_api.context.ContextPropagation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+class ContextPropagationTest {
+    @AfterEach
+    void tearDown() {
+        Context.reset();
+    }
+
+    @Test
+    void wrapRunnableReturnsNullForNullTask() {
+        Assertions.assertNull(ContextPropagation.wrap((Runnable) null));
+    }
+
+    @Test
+    void wrapCallableReturnsNullForNullTask() {
+        Assertions.assertNull(ContextPropagation.wrap((Callable<Object>) null));
+    }
+
+    @Test
+    void wrapRunnableReturnsOriginalTaskWhenNoContextIsSet() {
+        Runnable task = () -> {};
+
+        Runnable wrapped = ContextPropagation.wrap(task);
+
+        Assertions.assertSame(task, wrapped);
+    }
+
+    @Test
+    void wrapCallableReturnsOriginalTaskWhenNoContextIsSet() {
+        Callable<String> task = () -> "ok";
+
+        Callable<String> wrapped = ContextPropagation.wrap(task);
+
+        Assertions.assertSame(task, wrapped);
+    }
+
+    @Test
+    void wrapRunnableReturnsSameTaskWhenAlreadyWrapped() {
+        ContextObject contextObject = new ContextObject();
+        Runnable task = new ContextPropagatingRunnable(() -> {}, contextObject);
+
+        Runnable wrapped = ContextPropagation.wrap(task);
+
+        Assertions.assertSame(task, wrapped);
+    }
+
+    @Test
+    void wrapCallableReturnsSameTaskWhenAlreadyWrapped() {
+        ContextObject contextObject = new ContextObject();
+        Callable<String> task = new ContextPropagatingCallable<>(() -> "ok", contextObject);
+
+        Callable<String> wrapped = ContextPropagation.wrap(task);
+
+        Assertions.assertSame(task, wrapped);
+    }
+
+    @Test
+    void wrapRunnableCapturesCurrentContext() {
+        ContextObject requestContext = new ContextObject();
+        Context.set(requestContext);
+
+        AtomicReference<ContextObject> contextDuringRun = new AtomicReference<>();
+        Runnable wrapped = ContextPropagation.wrap(() -> contextDuringRun.set(Context.get()));
+
+        Context.reset();
+        wrapped.run();
+
+        Assertions.assertSame(requestContext, contextDuringRun.get());
+        Assertions.assertNull(Context.get(), "Expected worker context to be cleared after task execution");
+    }
+
+    @Test
+    void wrapCallableCapturesCurrentContext() throws Exception {
+        ContextObject requestContext = new ContextObject();
+        Context.set(requestContext);
+
+        Callable<ContextObject> wrapped = ContextPropagation.wrap(Context::get);
+
+        Context.reset();
+        ContextObject contextDuringCall = wrapped.call();
+
+        Assertions.assertSame(requestContext, contextDuringCall);
+        Assertions.assertNull(Context.get(), "Expected worker context to be cleared after task execution");
+    }
+
+    @Test
+    void contextPropagatingRunnableRestoresPreviousWorkerContext() {
+        ContextObject capturedContext = new ContextObject();
+        ContextObject previousWorkerContext = new ContextObject();
+
+        ContextPropagatingRunnable task = new ContextPropagatingRunnable(
+            () -> Assertions.assertSame(capturedContext, Context.get()),
+            capturedContext
+        );
+
+        Context.set(previousWorkerContext);
+        task.run();
+
+        Assertions.assertSame(previousWorkerContext, Context.get());
+    }
+
+    @Test
+    void contextPropagatingCallableRestoresPreviousWorkerContext() throws Exception {
+        ContextObject capturedContext = new ContextObject();
+        ContextObject previousWorkerContext = new ContextObject();
+
+        ContextPropagatingCallable<ContextObject> task = new ContextPropagatingCallable<>(
+            Context::get,
+            capturedContext
+        );
+
+        Context.set(previousWorkerContext);
+        ContextObject contextDuringCall = task.call();
+
+        Assertions.assertSame(capturedContext, contextDuringCall);
+        Assertions.assertSame(previousWorkerContext, Context.get());
+    }
+
+    @Test
+    void contextPropagatingRunnableClearsContextWhenWorkerHadNoPreviousContext() {
+        ContextObject capturedContext = new ContextObject();
+
+        ContextPropagatingRunnable task = new ContextPropagatingRunnable(
+            () -> Assertions.assertSame(capturedContext, Context.get()),
+            capturedContext
+        );
+
+        Context.reset();
+        task.run();
+
+        Assertions.assertNull(Context.get());
+    }
+
+    @Test
+    void contextPropagatingCallableClearsContextWhenWorkerHadNoPreviousContext() throws Exception {
+        ContextObject capturedContext = new ContextObject();
+
+        ContextPropagatingCallable<ContextObject> task = new ContextPropagatingCallable<>(
+            Context::get,
+            capturedContext
+        );
+
+        Context.reset();
+        ContextObject contextDuringCall = task.call();
+
+        Assertions.assertSame(capturedContext, contextDuringCall);
+        Assertions.assertNull(Context.get());
+    }
+
+    @Test
+    void contextPropagatingRunnableRestoresPreviousWorkerContextAfterException() {
+        ContextObject capturedContext = new ContextObject();
+        ContextObject previousWorkerContext = new ContextObject();
+
+        ContextPropagatingRunnable task = new ContextPropagatingRunnable(
+            () -> {
+                throw new IllegalStateException("boom");
+            },
+            capturedContext
+        );
+
+        Context.set(previousWorkerContext);
+
+        Assertions.assertThrows(IllegalStateException.class, task::run);
+        Assertions.assertSame(previousWorkerContext, Context.get());
+    }
+
+    @Test
+    void contextPropagatingCallableRestoresPreviousWorkerContextAfterException() {
+        ContextObject capturedContext = new ContextObject();
+        ContextObject previousWorkerContext = new ContextObject();
+
+        ContextPropagatingCallable<String> task = new ContextPropagatingCallable<>(
+            () -> {
+                throw new IllegalStateException("boom");
+            },
+            capturedContext
+        );
+
+        Context.set(previousWorkerContext);
+
+        Assertions.assertThrows(IllegalStateException.class, task::call);
+        Assertions.assertSame(previousWorkerContext, Context.get());
+    }
+
+    @Test
+    void wrappedRunnableRunsDelegate() {
+        ContextObject requestContext = new ContextObject();
+        Context.set(requestContext);
+
+        AtomicBoolean delegateCalled = new AtomicBoolean(false);
+        Runnable wrapped = ContextPropagation.wrap(() -> delegateCalled.set(true));
+
+        Context.reset();
+        wrapped.run();
+
+        Assertions.assertTrue(delegateCalled.get());
+    }
+
+    @Test
+    void wrappedCallableReturnsDelegateResult() throws Exception {
+        ContextObject requestContext = new ContextObject();
+        Context.set(requestContext);
+
+        Callable<String> wrapped = ContextPropagation.wrap(() -> "ok");
+
+        Context.reset();
+
+        Assertions.assertEquals("ok", wrapped.call());
+    }
+}

--- a/agent_api/src/test/java/wrappers/ExecutorWrapperTest.java
+++ b/agent_api/src/test/java/wrappers/ExecutorWrapperTest.java
@@ -1,0 +1,81 @@
+package wrappers;
+
+import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.context.ContextObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ExecutorWrapperTest {
+    @AfterEach
+    void tearDown() {
+        Context.reset();
+    }
+
+    @Test
+    void scheduledThreadPoolExecutorSchedulePropagatesContext() throws Exception {
+        ContextObject ctx = new ContextObject();
+        Context.set(ctx);
+        ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
+        try {
+            assertSame(ctx, executor.schedule(Context::get, 0, TimeUnit.MILLISECONDS).get(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void delegatedSingleThreadExecutorSubmitPropagatesContext() throws Exception {
+        ContextObject ctx = new ContextObject();
+        Context.set(ctx);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            assertSame(ctx, executor.submit(Context::get).get(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void threadPoolExecutorExecutePropagatesContext() throws Exception {
+        ContextObject ctx = new ContextObject();
+        Context.set(ctx);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+        AtomicReference<ContextObject> onWorker = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        try {
+            executor.execute(() -> {
+                onWorker.set(Context.get());
+                done.countDown();
+            });
+            done.await(5, TimeUnit.SECONDS);
+            assertSame(ctx, onWorker.get());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void forkJoinPoolSubmitPropagatesContext() throws Exception {
+        ContextObject ctx = new ContextObject();
+        Context.set(ctx);
+        ForkJoinPool executor = new ForkJoinPool(1);
+        try {
+            assertSame(ctx, executor.submit(Context::get).get(5, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/end2end/spring_boot_postgres.py
+++ b/end2end/spring_boot_postgres.py
@@ -6,6 +6,27 @@ spring_boot_postgres_app.add_payload("sql",
     safe_request=Request("/api/pets/create", body={"name": "Bobby"}),
     unsafe_request=Request("/api/pets/create", body={"name": "Malicious Pet', 'Gru from the Minions') -- "})
 )
+
+for endpoint in [
+    "completable-future-single",
+    "submit-callable",
+    "thread-pool-execute",
+    "fork-join-submit",
+    "scheduled-callable",
+    "spring-task-executor",
+    "spring-async-annotation",
+]:
+    spring_boot_postgres_app.add_payload(
+        f"sql async context propagation {endpoint}",
+        safe_request=Request(
+            f"/api/pets/create/async/{endpoint}",
+            body={"name": "Bobby"}
+        ),
+        unsafe_request=Request(
+            f"/api/pets/create/async/{endpoint}",
+            body={"name": "Malicious Pet', 'Gru from the Minions') -- "}
+        )
+    )
 spring_boot_postgres_app.add_payload("command injection",
     safe_request=Request("/api/commands/execute/Johnny", method='GET'),
     unsafe_request=Request("/api/commands/execute/%27%3B%20sleep%202%3B%20%23%20", method='GET'),

--- a/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationConfig.java
+++ b/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationConfig.java
@@ -1,0 +1,23 @@
+package com.example.demo;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncContextPropagationConfig {
+    @Bean(name = "asyncContextPropagationExecutor")
+    public Executor asyncContextPropagationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("async-context-");
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationController.java
+++ b/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationController.java
@@ -1,0 +1,138 @@
+package com.example.demo;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.concurrent.*;
+
+@RestController
+@RequestMapping("/api/pets/create/async")
+public class AsyncContextPropagationController {
+    private final Executor springExecutor;
+    private final AsyncContextPropagationService asyncContextPropagationService;
+
+    public AsyncContextPropagationController(
+        @Qualifier("asyncContextPropagationExecutor") Executor springExecutor,
+        AsyncContextPropagationService asyncContextPropagationService
+    ) {
+        this.springExecutor = springExecutor;
+        this.asyncContextPropagationService = asyncContextPropagationService;
+    }
+
+    private record PetCreate(String name) {}
+
+    @PostMapping(
+        path = "/completable-future-single",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows completableFutureSingle(@RequestBody PetCreate pet) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            return CompletableFuture
+                .supplyAsync(() -> createPet(pet.name()), executor)
+                .get();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @PostMapping(
+        path = "/submit-callable",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows submitCallable(@RequestBody PetCreate pet) throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            return executor.submit(() -> createPet(pet.name())).get();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @PostMapping(
+        path = "/thread-pool-execute",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows threadPoolExecute(@RequestBody PetCreate pet) throws Exception {
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
+        try {
+            CompletableFuture<PetsController.Rows> future = new CompletableFuture<>();
+            executor.execute(() -> {
+                try {
+                    future.complete(createPet(pet.name()));
+                } catch (Throwable throwable) {
+                    future.completeExceptionally(throwable);
+                }
+            });
+            return future.get();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @PostMapping(
+        path = "/fork-join-submit",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows forkJoinSubmit(@RequestBody PetCreate pet) throws Exception {
+        return ForkJoinPool.commonPool()
+            .submit(() -> createPet(pet.name()))
+            .get();
+    }
+
+    @PostMapping(
+        path = "/scheduled-callable",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows scheduledCallable(@RequestBody PetCreate pet) throws Exception {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        try {
+            return executor.schedule(
+                () -> createPet(pet.name()),
+                1,
+                TimeUnit.MILLISECONDS
+            ).get();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @PostMapping(
+        path = "/spring-task-executor",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows springTaskExecutor(@RequestBody PetCreate pet) throws Exception {
+        CompletableFuture<PetsController.Rows> future = new CompletableFuture<>();
+        springExecutor.execute(() -> {
+            try {
+                future.complete(createPet(pet.name()));
+            } catch (Throwable throwable) {
+                future.completeExceptionally(throwable);
+            }
+        });
+        return future.get();
+    }
+
+    @PostMapping(
+        path = "/spring-async-annotation",
+        consumes = MediaType.APPLICATION_JSON_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public PetsController.Rows springAsyncAnnotation(@RequestBody PetCreate pet) throws Exception {
+        return asyncContextPropagationService
+            .createPetWithAsyncAnnotation(pet.name())
+            .get();
+    }
+
+    private PetsController.Rows createPet(String name) {
+        Integer rowsCreated = DatabaseHelper.createPetByName(name);
+        return new PetsController.Rows(rowsCreated);
+    }
+}

--- a/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationService.java
+++ b/sample-apps/SpringBootPostgres/src/main/java/com/example/demo/AsyncContextPropagationService.java
@@ -1,0 +1,15 @@
+package com.example.demo;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class AsyncContextPropagationService {
+    @Async("asyncContextPropagationExecutor")
+    public CompletableFuture<PetsController.Rows> createPetWithAsyncAnnotation(String name) {
+        Integer rowsCreated = DatabaseHelper.createPetByName(name);
+        return CompletableFuture.completedFuture(new PetsController.Rows(rowsCreated));
+    }
+}


### PR DESCRIPTION
## Summary
`Context` lives in a `ThreadLocal`, so it's only visible on the request-handling thread. When request-controlled input reaches a sink from a worker thread (`ExecutorService`, `@Async`, `CompletableFuture`, `ForkJoinPool`, a one-shot scheduled task), `Context.get()` returns `null` and scanning is silently skipped. This captures the context at task-submit time and restores it while the task runs on the worker.

## Why this is a prerequisite
This unblocks two things:
1. **Async context in general** — any Zen check whose sink runs on a worker thread (async SQL, file access, etc.).
2. **Async HTTP clients whose call runs on a `java.util.concurrent` executor.** The concrete case is OkHttp's `enqueue()`: its `Dispatcher` is a `ThreadPoolExecutor`, so the call's DNS resolve + connect run on a worker thread. More generally, any outbound call made from a `@Async` / `CompletableFuture` / executor worker. Without propagation these see `Context.get() == null` and their SSRF / outbound-domain checks silently miss.

> Netty-event-loop clients (Reactor Netty / Spring WebClient, Vert.x, AsyncHttpClient, AWS SDK async) do **not** go through these executors — they connect on Netty event loops and carry context via a channel attribute, which is handled separately, not by this PR.

## What changed
- `ContextPropagation` + `ContextPropagatingRunnable/Callable`: capture the active `ContextObject` at submit, set it around the task, restore the worker's previous context afterwards. Idempotent; no-op when there's no context.
- Executor wrappers: `ExecutorService.submit`, `ThreadPoolExecutor.execute`, `ForkJoinPool`, `ScheduledThreadPoolExecutor.schedule`, and the `Executors$Delegated*` wrappers. Periodic `scheduleAtFixedRate/WithFixedDelay` are intentionally not wrapped — a request context must not persist across periods.
- `ExecutorContextPropagation`: cached reflection bridge from the bootstrap-woven advice to `agent_api`. A not-yet-set jar path during early startup is retried rather than permanently disabling propagation.

## Testing
- Unit `ContextPropagationTest`: capture / restore / idempotency / exception paths.
- Integration `ExecutorWrapperTest` (runs under the agent): real `ThreadPoolExecutor`, `ForkJoinPool`, `ScheduledThreadPoolExecutor.schedule`, and `Executors.newSingleThreadExecutor()` propagate context to their worker threads.
- E2E `spring_boot_postgres`: async SQLi across `CompletableFuture`, `ExecutorService`, `ThreadPoolExecutor`, `ForkJoinPool`, `ScheduledThreadPoolExecutor`, and Spring `@Async`.

## Not covered
Reactor/WebFlux context (separate), raw `new Thread(...)`, periodic scheduled tasks, Kotlin coroutines, custom executors outside the covered JDK/Spring paths.
