### PR TITLE
Strip port from the raw remote address, not just X-Forwarded-For

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/ProxyForwardedParser.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/ProxyForwardedParser.java
@@ -18,8 +18,11 @@ public class ProxyForwardedParser {
             }
         }
 
-        // If no valid IP was found, or if X-Forwarded-For was not present, default to raw ip:
-        return rawIp;
+        // No (trusted) forwarding header: fall back to the raw socket address.
+        // Some servers/proxies hand us "ip:port" here too, so strip the port as
+        // well, otherwise the port ends up in attacks, rate limiting and the
+        // reported user IPs (which causes duplicate IPs on the cloud side).
+        return stripPort(rawIp);
     }
 
     /**
@@ -30,22 +33,55 @@ public class ProxyForwardedParser {
         return trustProxy.getValue();
     }
 
+    /**
+     * Strips a trailing port from an IP address, returning the bare IP. Handles
+     * IPv4 with a port ("1.2.3.4:5678") and bracketed IPv6 with a port
+     * ("[2001:db8::1]:5678"). Already-valid IPs (including bare IPv6) and values
+     * from which no port can be safely removed are returned unchanged.
+     */
+    public static String stripPort(String ipAddress) {
+        if (ipAddress == null) {
+            return null;
+        }
+        String ip = ipAddress.trim();
+
+        if (IPValidator.isIP(ip)) {
+            return ip;
+        }
+
+        // Bracketed IPv6 with optional port, e.g. "[2001:db8::1]:5678".
+        if (ip.startsWith("[")) {
+            int closing = ip.indexOf(']');
+            if (closing > 1) {
+                String inner = ip.substring(1, closing);
+                if (IPValidator.isIP(inner, "6")) {
+                    return inner;
+                }
+            }
+            return ip;
+        }
+
+        // IPv4 with a port, e.g. "1.2.3.4:5678". A single colon distinguishes this
+        // from a bare IPv6 address, which always has multiple colons.
+        int firstColon = ip.indexOf(':');
+        if (firstColon > -1 && ip.indexOf(':', firstColon + 1) == -1) {
+            String candidate = ip.substring(0, firstColon);
+            if (IPValidator.isIP(candidate, "4")) {
+                return candidate;
+            }
+        }
+
+        return ip;
+    }
+
     private static String extractIpFromHeader(String xForwardedForHeader) {
         String[] ips = xForwardedForHeader.split(",");
         for (String ip: ips) {
-            ip = ip.trim();
-
-            // Some proxies pass along port numbers inside x-forwarded-for :
-            if (ip.contains(":")) {
-                String[] ipParts = ip.split(":");
-                if (ipParts.length == 2 && IPValidator.isIP(ipParts[0])) {
-                    return ipParts[0];
-                }
-            }
-
-            // Continue to check the IPs :
-            if (IPValidator.isIP(ip)) {
-                return ip;
+            // Some proxies pass along port numbers inside x-forwarded-for, so
+            // strip them before validating.
+            String cleaned = stripPort(ip.trim());
+            if (IPValidator.isIP(cleaned)) {
+                return cleaned;
             }
         }
         return null;

--- a/agent_api/src/test/java/helpers/ProxyForwardedParserTest.java
+++ b/agent_api/src/test/java/helpers/ProxyForwardedParserTest.java
@@ -7,6 +7,8 @@ import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import java.util.HashMap;
 import java.util.List;
 
+import dev.aikido.agent_api.helpers.net.ProxyForwardedParser;
+
 import static dev.aikido.agent_api.helpers.net.ProxyForwardedParser.getIpFromRequest;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -144,5 +146,48 @@ class ProxyForwardedParserTest {
         headers.put("X-Forwarded-For", List.of(",5.6.7.8,,"));
         String result = getIpFromRequest("1.2.3.4", headers);
         assertEquals("5.6.7.8", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_StripsPortFromRawIp() {
+        // No forwarding header present: the raw socket address can still carry a
+        // port, which must be stripped so it doesn't leak to the cloud side.
+        String result = getIpFromRequest("109.132.232.101:58780", new HashMap<>());
+        assertEquals("109.132.232.101", result);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "AIKIDO_TRUST_PROXY", value = "0")
+    void testGetIpFromRequest_StripsPortFromRawIp_TrustProxyFalse() {
+        headers.put("X-Forwarded-For", List.of("192.168.1.1, 203.0.113.5"));
+        String result = getIpFromRequest("109.132.232.101:58780", headers);
+        assertEquals("109.132.232.101", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_KeepsBareRawIpv6() {
+        String result = getIpFromRequest("2001:db8::1", new HashMap<>());
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_StripsPortFromBracketedIpv6InHeader() {
+        headers.put("X-Forwarded-For", List.of("[2001:db8::1]:8080, 203.0.113.5"));
+        String result = getIpFromRequest("10.0.0.1", headers);
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    void testStripPort() {
+        assertEquals("1.2.3.4", ProxyForwardedParser.stripPort("1.2.3.4"));
+        assertEquals("1.2.3.4", ProxyForwardedParser.stripPort("1.2.3.4:5678"));
+        assertEquals("1.2.3.4", ProxyForwardedParser.stripPort("  1.2.3.4:5678 "));
+        assertEquals("2001:db8::1", ProxyForwardedParser.stripPort("2001:db8::1"));
+        assertEquals("2001:db8::1", ProxyForwardedParser.stripPort("[2001:db8::1]:5678"));
+        assertEquals("2001:db8::1", ProxyForwardedParser.stripPort("[2001:db8::1]"));
+        // Nothing strippable: returned unchanged.
+        assertEquals("not-an-ip", ProxyForwardedParser.stripPort("not-an-ip"));
+        assertEquals("garbage:1234", ProxyForwardedParser.stripPort("garbage:1234"));
+        assertNull(ProxyForwardedParser.stripPort(null));
     }
 }


### PR DESCRIPTION
## Problem

`ProxyForwardedParser` only strips an ephemeral source port when the client IP comes from `X-Forwarded-For`. When there is no trusted forwarding header (no proxy, or `AIKIDO_TRUST_PROXY=false`), `getIpFromRequest()` returns the **raw socket address as-is**:

```java
// If no valid IP was found, or if X-Forwarded-For was not present, default to raw ip:
return rawIp;
```

So an `ip:port` value (e.g. `109.132.232.101:58780`) can flow straight through into attacks, rate limiting and the reported user IPs.

On the cloud side this is the root cause of **duplicate runtime-user IP rows** — the dedup key there is `user_id|ip_address`, so the same real client IP with different source ports is stored as separate rows. It also previously crashed the GeoIP lookup (`InvalidArgumentException: The value "109.132.232.101:58780" is not a valid IP address`).

The X-Forwarded-For strip has shipped since the first release (v0.1.4), yet the cloud still received ported IPv4 values from Java apps — because they arrive via this raw-IP path, which was never normalized.

## Fix

- Extract a `stripPort()` helper and apply it to the raw-IP fallback as well, so the port is removed regardless of whether the IP came from a header or the socket.
- `stripPort()` handles IPv4 with a port (`1.2.3.4:5678`) and bracketed IPv6 with a port (`[2001:db8::1]:5678`), and leaves already-valid IPs (including bare IPv6) and non-IP values untouched.
- `extractIpFromHeader()` now reuses the same helper, which also adds bracketed-IPv6 port stripping to the X-Forwarded-For path (previously IPv4-only).

## Tests

Added to `ProxyForwardedParserTest`:
- port stripped from the raw IP fallback (with and without a forwarding header / `AIKIDO_TRUST_PROXY=false`),
- bare IPv6 raw IP left unchanged,
- bracketed IPv6 with a port stripped in `X-Forwarded-For`,
- direct `stripPort()` unit coverage (IPv4:port, bare/bracketed IPv6, whitespace, non-IP passthrough, null).

All `ProxyForwardedParserTest` cases pass. The remaining failures in the full `:agent_api:test` run are pre-existing and environment-related (SSRF tests needing DNS, MySQL/MariaDB/MSSQL tests needing live databases, platform musl/gnu binary path) — none touch this code.

## Related

Complements the cloud-side guard in `aikido-core` that normalizes the IP at ingestion (defense in depth). This PR removes the port at the source; the core guard catches any older/other-language agents that still send it.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Introduced stripPort helper, updated header parsing, and added tests

**🐛 Bugfixes**
* Stripped ephemeral ports from raw socket IP fallback to normalize addresses


<sup>[More info](https://app.aikido.dev/featurebranch/scan/136853481?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->