### PR TITLE
Normalize raw remote IP addresses with ports

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/ProxyForwardedParser.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/ProxyForwardedParser.java
@@ -19,6 +19,11 @@ public class ProxyForwardedParser {
         }
 
         // If no valid IP was found, or if X-Forwarded-For was not present, default to raw ip:
+        String normalizedRawIp = normalizeIp(rawIp);
+        if (normalizedRawIp != null) {
+            return normalizedRawIp;
+        }
+
         return rawIp;
     }
 
@@ -35,19 +40,50 @@ public class ProxyForwardedParser {
         for (String ip: ips) {
             ip = ip.trim();
 
-            // Some proxies pass along port numbers inside x-forwarded-for :
-            if (ip.contains(":")) {
-                String[] ipParts = ip.split(":");
-                if (ipParts.length == 2 && IPValidator.isIP(ipParts[0])) {
-                    return ipParts[0];
-                }
-            }
-
-            // Continue to check the IPs :
-            if (IPValidator.isIP(ip)) {
-                return ip;
+            String normalizedIp = normalizeIp(ip);
+            if (normalizedIp != null) {
+                return normalizedIp;
             }
         }
+        return null;
+    }
+
+    private static String normalizeIp(String ip) {
+        if (ip == null || ip.isEmpty()) {
+            return null;
+        }
+
+        ip = ip.trim();
+
+        if (IPValidator.isIP(ip)) {
+            return ip;
+        }
+
+        if (ip.startsWith("[") && ip.endsWith("]")) {
+            String unwrappedIp = ip.substring(1, ip.length() - 1);
+            if (IPValidator.isIP(unwrappedIp)) {
+                return unwrappedIp;
+            }
+        }
+
+        if (ip.startsWith("[")) {
+            int closingBracket = ip.indexOf("]:");
+            if (closingBracket > 0) {
+                String unwrappedIp = ip.substring(1, closingBracket);
+                if (IPValidator.isIP(unwrappedIp)) {
+                    return unwrappedIp;
+                }
+            }
+        }
+
+        // Some proxies pass along port numbers with IP addresses :
+        if (ip.contains(":")) {
+            String[] ipParts = ip.split(":");
+            if (ipParts.length == 2 && IPValidator.isIP(ipParts[0], "4")) {
+                return ipParts[0];
+            }
+        }
+
         return null;
     }
 

--- a/agent_api/src/test/java/SetUserTest.java
+++ b/agent_api/src/test/java/SetUserTest.java
@@ -1,6 +1,7 @@
 import dev.aikido.agent_api.SetUser;
 import dev.aikido.agent_api.context.Context;
 import dev.aikido.agent_api.context.ContextObject;
+import dev.aikido.agent_api.context.JavalinContextObject;
 import dev.aikido.agent_api.storage.UsersStore;
 import org.junit.jupiter.api.*;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
@@ -133,5 +134,26 @@ public class SetUserTest {
         SetUser.setUser(new SetUser.UserObject("ID", "Name"));
         assertFalse(out.capturedString().contains("SetUser")); // Should not contain SetUser class
         assertEquals(1, UsersStore.getUsersAsList().size());
+    }
+
+    @Test
+    void testSetUserUsesNormalizedIpFromContext() {
+        ContextObject contextObject = new JavalinContextObject(
+            "GET",
+            "http://example.com",
+            "109.132.232.101:58780",
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>()
+        );
+
+        Context.set(contextObject);
+
+        SetUser.setUser(new SetUser.UserObject("admin", "Admin"));
+
+        assertNotNull(Context.get().getUser());
+        assertEquals("109.132.232.101", Context.get().getUser().lastIpAddress());
+
+        Context.reset();
     }
 }

--- a/agent_api/src/test/java/context/JavalinContextObjectTest.java
+++ b/agent_api/src/test/java/context/JavalinContextObjectTest.java
@@ -103,4 +103,18 @@ class JavalinContextObjectTest {
         assertEquals("user456", contextObject.getCookies().get("userId").get(0));
         assertEquals(2, contextObject.getCookies().size());
     }
+
+    @Test
+    void testConstructorStripsPortFromRawIp() {
+        JavalinContextObject contextObject = new JavalinContextObject(
+            "GET",
+            "http://example.com",
+            "109.132.232.101:58780",
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>()
+        );
+
+        assertEquals("109.132.232.101", contextObject.getRemoteAddress());
+    }
 }

--- a/agent_api/src/test/java/helpers/ProxyForwardedParserTest.java
+++ b/agent_api/src/test/java/helpers/ProxyForwardedParserTest.java
@@ -145,4 +145,73 @@ class ProxyForwardedParserTest {
         String result = getIpFromRequest("1.2.3.4", headers);
         assertEquals("5.6.7.8", result);
     }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithIPv4Port() {
+        String result = getIpFromRequest("109.132.232.101:58780", new HashMap<>());
+        assertEquals("109.132.232.101", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithBracketedIPv6Port() {
+        String result = getIpFromRequest("[2001:db8::1]:443", new HashMap<>());
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithBracketedIPv6WithoutPort() {
+        String result = getIpFromRequest("[2001:db8::1]", new HashMap<>());
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_XForwardedForWithBracketedIPv6Port() {
+        headers.put("X-Forwarded-For", List.of("[2001:db8::1]:443, 203.0.113.5"));
+        String result = getIpFromRequest("10.0.0.1", headers);
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "AIKIDO_TRUST_PROXY", value = "0")
+    void testGetIpFromRequest_TrustProxyFalseStillNormalizesRawIp() {
+        headers.put("X-Forwarded-For", List.of("1.2.3.4"));
+        String result = getIpFromRequest("109.132.232.101:58780", headers);
+        assertEquals("109.132.232.101", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithPlainIPv4() {
+        String result = getIpFromRequest("109.132.232.101", new HashMap<>());
+        assertEquals("109.132.232.101", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithPlainIPv6() {
+        String result = getIpFromRequest("2001:db8::1", new HashMap<>());
+        assertEquals("2001:db8::1", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithInvalidBracketedIpFallsBackToRawIp() {
+        String result = getIpFromRequest("[not-an-ip]", new HashMap<>());
+        assertEquals("[not-an-ip]", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithInvalidBracketedIpAndPortFallsBackToRawIp() {
+        String result = getIpFromRequest("[not-an-ip]:443", new HashMap<>());
+        assertEquals("[not-an-ip]:443", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithInvalidIPv4PortFallsBackToRawIp() {
+        String result = getIpFromRequest("not-an-ip:58780", new HashMap<>());
+        assertEquals("not-an-ip:58780", result);
+    }
+
+    @Test
+    void testGetIpFromRequest_RawIpWithEmptyStringFallsBackToRawIp() {
+        String result = getIpFromRequest("", new HashMap<>());
+        assertEquals("", result);
+    }
 }


### PR DESCRIPTION
## Summary

Normalize raw remote IP addresses before storing runtime user IPs.

In some servlet container configurations, the Java agent can receive a remote address in `ip:port` format through the raw request remote address path, not through the `X-Forwarded-For` parser.

This can happen with Spring Boot/Tomcat native forwarded-header handling: Tomcat consumes the `X-Forwarded-For` header and exposes its value through `request.getRemoteAddr()`.

Before this change, the fallback path returned `rawIp` unchanged. As a result, `SetUser` could store and report runtime user IPs like:

```text
109.132.232.101:58780
```

This caused the same client IP to be reported as multiple different runtime user IPs when the source port changed.

## Changes

* Added normalization for fallback raw remote addresses.
* Reused the same normalization for forwarded-header candidates.
* Handles:

  * plain IPv4 / IPv6
  * IPv4 with port, e.g. `109.132.232.101:58780`
  * bracketed IPv6, e.g. `[2001:db8::1]`
  * bracketed IPv6 with port, e.g. `[2001:db8::1]:443`
* Preserves the previous fallback behavior for values that cannot be parsed.

## Testing

Targeted tests:

```bash
./gradlew :agent_api:test --tests helpers.ProxyForwardedParserTest
./gradlew :agent_api:test --tests context.JavalinContextObjectTest
./gradlew :agent_api:test --tests SetUserTest
```

Covered cases:

* raw remote IPv4 address with source port
* bracketed IPv6 with port
* bracketed IPv6 without port
* `X-Forwarded-For` with bracketed IPv6 port
* trust-proxy-disabled fallback behavior
* `SetUser` using the normalized IP from request context

Local E2E smoke:

* Ran a Spring Boot/Tomcat test app with `--server.forward-headers-strategy=native`
* Set `AIKIDO_TRUST_PROXY=false`
* Sent `X-Forwarded-For: 109.132.232.101:58780`
* Verified Tomcat consumes the header and exposes it as raw remote address:

```json
{
  "remoteAddr": "109.132.232.101:58780",
  "xForwardedFor": null
}
```

* Redirected the Java agent to a local mock Aikido backend and captured heartbeat payloads.

Old agent behavior:

```json
"users": [
  {
    "id": "admin@tenant-a.test",
    "name": "Admin",
    "lastIpAddress": "109.132.232.101:58780"
  }
]
```

Fixed agent behavior:

```json
"users": [
  {
    "id": "admin@tenant-a.test",
    "name": "Admin",
    "lastIpAddress": "109.132.232.101"
  }
]
```

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Normalized raw remote IP addresses and ports before storing


<sup>[More info](https://app.aikido.dev/featurebranch/scan/136906082?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->