### PR TITLE
Fully ignore private IP literals as outbound connections (early return)

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -39,22 +39,25 @@ public final class DNSRecordCollector {
             // Removing them here ensures each (hostname, port) pair is counted exactly once.
             Set<Integer> ports = PendingHostnamesStore.getAndRemove(hostname);
 
-            // The outbound-domains list is meant for hostnames, not raw IP literals.
-            // A private/internal IP literal passed straight to getAllByName (DNS-resolver
-            // bootstrap, service discovery connecting by IP, libraries building a private-IP
-            // matcher, ...) is not an outbound domain and would otherwise flood the
-            // "new outbound connection" feature. Skip recording those; SSRF/stored-SSRF and
-            // outbound-domain blocking below are unaffected.
-            boolean isPrivateIpLiteral = IsPrivateIP.isPrivateIp(hostname);
-            if (!isPrivateIpLiteral) {
-                if (!ports.isEmpty()) {
-                    for (int port : ports) {
-                        HostnamesStore.incrementHits(hostname, port);
-                    }
-                } else {
-                    // We still need to report a hit to the hostname for outbound domain blocking
-                    HostnamesStore.incrementHits(hostname, 0);
+            // Don't report private/internal IP literals as outbound connections, consistent
+            // with the other Zen agents. A raw private IP reaching getAllByName is infrastructure,
+            // not a real outbound domain: the Reactor Netty resolver bootstrap resolving the
+            // any-address/nameservers, service discovery connecting by IP, a library building a
+            // private-IP matcher, etc. We fully return so we also skip outbound blocking below;
+            // otherwise lockdown mode (blockNewOutgoingRequests) would block these internal
+            // resolutions and break the application. Real domains that resolve to private IPs are
+            // not literals, so they fall through and are still tracked and SSRF-checked.
+            if (IsPrivateIP.isPrivateIp(hostname)) {
+                return;
+            }
+
+            if (!ports.isEmpty()) {
+                for (int port : ports) {
+                    HostnamesStore.incrementHits(hostname, port);
                 }
+            } else {
+                // We still need to report a hit to the hostname for outbound domain blocking
+                HostnamesStore.incrementHits(hostname, 0);
             }
 
             // Block if the hostname is in the blocked domains list

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -278,4 +278,34 @@ public class DNSRecordCollectorTest {
         assertEquals(1, entries.length);
         assertEquals("1.1.1.1", entries[0].getHostname());
     }
+
+    @Test
+    public void testPrivateIpLiteralNotBlockedInLockdownMode() throws UnknownHostException {
+        // Lockdown (blockNewOutgoingRequests=true) blocks any host not on the allow list.
+        // A private IP literal must be fully ignored via early return, so it is neither
+        // recorded nor blocked; otherwise lockdown would break internal resolutions.
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        InetAddress[] resolved = new InetAddress[]{InetAddress.getByName("10.0.0.0")};
+
+        assertDoesNotThrow(() -> DNSRecordCollector.report("10.0.0.0", resolved));
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPrivateIpLiteralViaUrlInLockdownNotBlockedNorRecorded() throws UnknownHostException {
+        // http://10.0.0.1:8080 -> URLCollector registers pending port 8080, then
+        // getAllByName("10.0.0.1"). The private IP is fully ignored: not recorded, not blocked
+        // in lockdown, and the pending port is still consumed.
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        PendingHostnamesStore.add("10.0.0.1", 8080);
+        InetAddress[] resolved = new InetAddress[]{InetAddress.getByName("10.0.0.1")};
+
+        assertDoesNotThrow(() -> DNSRecordCollector.report("10.0.0.1", resolved));
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+        assertTrue(PendingHostnamesStore.getPorts("10.0.0.1").isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #308. The agent records every `getAllByName()` argument as an outbound connection, including raw private/internal IP literals. Those come from infrastructure, not real outbound domains, and flooded the "new outbound connection" feature with private IPs on port 0.

Sources we confirmed:
- **Reactor Netty (WebClient / Netty-backed RestClient) resolver bootstrap** on the first client call: `0.0.0.0` and `::` from `io.netty.channel.epoll.Native.<clinit>`, and each `/etc/resolv.conf` nameserver via `UnixResolverDnsServerAddressStreamProvider` (private on ECS: VPC resolver `10.x`, `169.254.169.253`, `127.0.0.53`).
- Service discovery connecting by IP (`10.20.x.x`), and a startup library resolving RFC1918 base addresses (`10.0.0.0`, `172.16.0.0`, ...).

## The fix

`DNSRecordCollector.report()` returns early when the looked-up host is a private IP literal:

```java
Set<Integer> ports = PendingHostnamesStore.getAndRemove(hostname);

if (IsPrivateIP.isPrivateIp(hostname)) {
    return;
}
// ... record hostname, outbound blocking, SSRF (unchanged) ...
```

#308 only skipped the `HostnamesStore` record but still fell through to the outbound-domain blocking check. In lockdown mode (`blockNewOutgoingRequests`) that would block these internal resolutions and break the app. The early return skips both the record and the block, consistent with the other Zen agents.

## Behaviour

| Scenario | Result |
|---|---|
| Resolve or connect to a private IP literal (`getAllByName("10.20.11.143")`, or Netty bootstrap resolving `0.0.0.0` / nameservers) | Fully ignored. Not recorded as an outbound connection, and not run through outbound blocking, so lockdown mode does not block it. |
| Private IP reached via a URL (`http://10.0.0.1:8080`) | `URLCollector` registers the pending port, then `getAllByName("10.0.0.1")` returns early. Nothing recorded, not blocked in lockdown, and the pending port is still consumed. |
| Outbound to a real domain, including internal names that resolve to a private IP (`keycloak.internal...`) | Unchanged. Hostname recorded, lockdown still applies, SSRF / stored-SSRF still run on the resolved IPs. |
| Public IP literal | Unchanged. Still recorded. |

SSRF is unaffected: it never fires on an IP literal (`hostname == ip` is treated as "no resolution, safe"), and real domains do not hit the early return.

## Tests

- `testPrivateIpLiteralNotRecordedAsOutboundHostname`, `testPrivateIpLiteralWithPendingPortStillConsumedButNotRecorded` (from #308) still pass.
- `testPrivateIpLiteralNotBlockedInLockdownMode` — a private IP literal is not blocked in lockdown mode.
- `testPrivateIpLiteralViaUrlInLockdownNotBlockedNorRecorded` — private IP via URL: not recorded, not blocked, pending port consumed.
- `testHostnameResolvingToPrivateIpStillRecorded`, `testPublicIpLiteralStillRecorded` confirm domains and public IPs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Ignored private IP literals early to prevent recording and blocking


<sup>[More info](https://app.aikido.dev/featurebranch/scan/137817121?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->