### PR TITLE
Track and protect WebClient outbound requests, fix private-IP SSRF regression

### DIFF
--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compileOnly 'io.projectreactor.netty:reactor-netty-http:1.2.1' // For Spring Webflux
     compileOnly 'io.javalin:javalin:6.4.0'
     compileOnly 'org.springframework:spring-web:5.3.20'
+    compileOnly 'org.springframework:spring-webflux:5.3.20' // For Spring WebClient
 }
 
 shadowJar {

--- a/agent/src/main/java/dev/aikido/agent/Wrappers.java
+++ b/agent/src/main/java/dev/aikido/agent/Wrappers.java
@@ -33,6 +33,7 @@ public final class Wrappers {
             new HttpURLConnectionWrapper(),
             new InetAddressWrapper(),
             new SocketChannelWrapper(),
+            new NettySocketChannelWrapper(),
             new HttpClientWrapper(),
             new HttpConnectionRedirectWrapper(),
             new HttpClientSendWrapper(),

--- a/agent/src/main/java/dev/aikido/agent/Wrappers.java
+++ b/agent/src/main/java/dev/aikido/agent/Wrappers.java
@@ -9,6 +9,8 @@ import dev.aikido.agent.wrappers.spring.SpringMVCJavaxWrapper;
 import dev.aikido.agent.wrappers.spring.SpringWebfluxWrapper;
 import dev.aikido.agent.wrappers.spring.SpringControllerWrapper;
 import dev.aikido.agent.wrappers.spring.SpringMVCJakartaWrapper;
+import dev.aikido.agent.wrappers.spring.SpringWebClientWrapper;
+import dev.aikido.agent.wrappers.spring.SpringWebClientRedirectWrapper;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,11 +32,14 @@ public final class Wrappers {
             // SSRF/HTTP wrappers
             new HttpURLConnectionWrapper(),
             new InetAddressWrapper(),
+            new SocketChannelWrapper(),
             new HttpClientWrapper(),
             new HttpConnectionRedirectWrapper(),
             new HttpClientSendWrapper(),
             new OkHttpWrapper(),
             new ApacheHttpClientWrapper(),
+            new SpringWebClientWrapper(),
+            new SpringWebClientRedirectWrapper(),
 
             new PathWrapper(),
             new PathsWrapper(),

--- a/agent/src/main/java/dev/aikido/agent/wrappers/NettySocketChannelWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/NettySocketChannelWrapper.java
@@ -1,0 +1,62 @@
+package dev.aikido.agent.wrappers;
+
+import dev.aikido.agent_api.collectors.DNSRecordCollector;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public class NettySocketChannelWrapper implements Wrapper {
+    // Referenced by name (not by .class): netty-transport is compileOnly here, only present on
+    // the target application's classloader.
+    private static final String ABSTRACT_CHANNEL_CLASS_NAME = "io.netty.channel.AbstractChannel";
+
+    public String getName() {
+        // doConnect(SocketAddress, SocketAddress) is the low-level connect entry point every
+        // Netty transport implementation overrides (NioSocketChannel, EpollSocketChannel,
+        // KQueueSocketChannel, ...). SocketChannelWrapper hooks java.nio.channels.SocketChannel,
+        // which only NioSocketChannel extends - Reactor Netty prefers its native epoll transport
+        // on Linux whenever the native library loads (the common case in production), and
+        // EpollSocketChannel implements Netty's own io.netty.channel.socket.SocketChannel
+        // interface instead, structurally unrelated to the JDK one despite the identical name.
+        // SocketChannelWrapper never sees those connections at all; this wrapper does regardless
+        // of which transport gets picked.
+        return NettyConnectAdvice.class.getName();
+    }
+
+    public ElementMatcher<? super MethodDescription> getMatcher() {
+        return ElementMatchers.named("doConnect").and(ElementMatchers.takesArguments(2));
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return ElementMatchers.hasSuperType(ElementMatchers.named(ABSTRACT_CHANNEL_CLASS_NAME));
+    }
+
+    public static class NettyConnectAdvice {
+        // No suppress: DNSRecordCollector.reportConnect() must be able to throw
+        // SSRFException/BlockedOutboundException through to actually abort the connect. It
+        // already contains every other exception internally (logs and swallows), so nothing
+        // unrelated escapes here.
+        @Advice.OnMethodEnter
+        public static void before(
+                @Advice.Argument(0) SocketAddress remoteAddress
+        ) throws Throwable {
+            if (!(remoteAddress instanceof InetSocketAddress)) {
+                return;
+            }
+            InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
+            InetAddress resolvedAddress = inetSocketAddress.getAddress();
+            if (resolvedAddress == null) {
+                // Unresolved: nothing to report yet, doConnect() will fail on its own.
+                return;
+            }
+            DNSRecordCollector.reportConnect(inetSocketAddress.getHostString(), resolvedAddress);
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/SocketChannelWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/SocketChannelWrapper.java
@@ -1,0 +1,87 @@
+package dev.aikido.agent.wrappers;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.channels.SocketChannel;
+
+public class SocketChannelWrapper implements Wrapper {
+    public String getName() {
+        // Wrap connect(SocketAddress) on SocketChannel. Clients that resolve hostnames with
+        // their own DNS resolver instead of InetAddress.getAllByName() (e.g. Reactor Netty's
+        // async resolver, used by default by Spring's WebClient) never trigger
+        // InetAddressWrapper, so this is the only point where we see the resolved address
+        // before the connection is made. Also catches literal IP targets, which never go
+        // through any resolver at all.
+        // https://docs.oracle.com/javase/8/docs/api/java/nio/channels/SocketChannel.html#connect-java.net.SocketAddress-
+        return SocketChannelAdvice.class.getName();
+    }
+    public ElementMatcher<? super MethodDescription> getMatcher() {
+        return ElementMatchers.named("connect");
+    }
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return ElementMatchers.isSubTypeOf(SocketChannel.class);
+    }
+    public static class SocketChannelAdvice {
+        // Since we have to wrap a native Java Class stuff gets more complicated
+        // The classpath is not the same anymore, and we can't import our modules directly.
+        // To bypass this issue we load collectors from a .jar file
+        @Advice.OnMethodEnter
+        public static void before(
+                @Advice.Argument(0) SocketAddress remoteAddress
+        ) throws Throwable {
+            if (!(remoteAddress instanceof InetSocketAddress)) {
+                return;
+            }
+            InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteAddress;
+            InetAddress resolvedAddress = inetSocketAddress.getAddress();
+            if (resolvedAddress == null) {
+                // Unresolved: nothing to report yet, connect() will throw on its own.
+                return;
+            }
+            String hostname = inetSocketAddress.getHostString();
+
+            String jarFilePath = System.getProperty("AIK_agent_api_jar");
+            URLClassLoader classLoader = null;
+            try {
+                URL[] urls = { new URL(jarFilePath) };
+                classLoader = new URLClassLoader(urls);
+            } catch (MalformedURLException ignored) {}
+            if (classLoader == null) {
+                return;
+            }
+
+            try {
+                // Load the class from the JAR
+                Class<?> clazz = classLoader.loadClass("dev.aikido.agent_api.collectors.DNSRecordCollector");
+
+                // Run reportConnect with "argument"
+                for (Method method2: clazz.getMethods()) {
+                    if(method2.getName().equals("reportConnect")) {
+                        method2.invoke(null, hostname, resolvedAddress);
+                        break;
+                    }
+                }
+                classLoader.close(); // Close the class loader
+            } catch (InvocationTargetException invocationTargetException) {
+                if(invocationTargetException.getCause().toString().startsWith("dev.aikido.agent_api.vulnerabilities")) {
+                    throw invocationTargetException.getCause();
+                }
+                // Ignore non-aikido throwables.
+            } catch(Throwable e) {
+                System.out.println("AIKIDO: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/SocketChannelWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/SocketChannelWrapper.java
@@ -17,12 +17,8 @@ import java.nio.channels.SocketChannel;
 
 public class SocketChannelWrapper implements Wrapper {
     public String getName() {
-        // Wrap connect(SocketAddress) on SocketChannel. Clients that resolve hostnames with
-        // their own DNS resolver instead of InetAddress.getAllByName() (e.g. Reactor Netty's
-        // async resolver, used by default by Spring's WebClient) never trigger
-        // InetAddressWrapper, so this is the only point where we see the resolved address
-        // before the connection is made. Also catches literal IP targets, which never go
-        // through any resolver at all.
+        // Catches clients with their own DNS resolver (e.g. Reactor Netty) that never trigger
+        // InetAddressWrapper, plus literal IP targets that skip resolution entirely.
         // https://docs.oracle.com/javase/8/docs/api/java/nio/channels/SocketChannel.html#connect-java.net.SocketAddress-
         return SocketChannelAdvice.class.getName();
     }

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientRedirectWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientRedirectWrapper.java
@@ -1,0 +1,66 @@
+package dev.aikido.agent.wrappers.spring;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import dev.aikido.agent_api.collectors.RedirectCollector;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+public class SpringWebClientRedirectWrapper implements Wrapper {
+    // Package-private in Reactor Netty, referenced by name only. This is the internal method
+    // that runs once per redirect hop, for both WebClient and the Netty-backed RestClient -
+    // Spring's own request-adaptation layer (ExchangeFunction/ReactorClientHttpRequest) is
+    // only invoked once per top-level call and never sees redirect targets for bodiless (e.g.
+    // GET) requests, since Reactor Netty resends internally without going back through it.
+    // Mirrors HttpConnectionRedirectWrapper, which hooks the JDK's equally-internal
+    // followRedirect0 for the same reason.
+    private static final String HTTP_CLIENT_HANDLER_CLASS_NAME =
+            "reactor.netty.http.client.HttpClientConnect$HttpClientHandler";
+
+    public String getName() {
+        return RedirectAdvice.class.getName();
+    }
+    public ElementMatcher<? super MethodDescription> getMatcher() {
+        return ElementMatchers.isDeclaredBy(getTypeMatcher())
+                .and(ElementMatchers.named("redirect"))
+                .and(ElementMatchers.takesArguments(1));
+    }
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return ElementMatchers.named(HTTP_CLIENT_HANDLER_CLASS_NAME);
+    }
+    public static class RedirectAdvice {
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void after(@Advice.This Object handler) throws Exception {
+            // fromURI/toURI are UriEndpoint (also package-private), both reassigned by
+            // redirect() before this advice runs: fromURI is the hostname that redirected,
+            // toURI is where it redirected to.
+            String origin = externalForm(handler, "fromURI");
+            String dest = externalForm(handler, "toURI");
+            if (origin == null || dest == null) {
+                return;
+            }
+            RedirectCollector.report(new URL(origin), new URL(dest));
+        }
+
+        // Must be public: after weaving, this is called as a real cross-class invocation from
+        // inside the target class's own bytecode, so a private method would raise IllegalAccessError.
+        public static String externalForm(Object handler, String fieldName) throws Exception {
+            Field field = handler.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            Object uriEndpoint = field.get(handler);
+            if (uriEndpoint == null) {
+                return null;
+            }
+            Method toExternalForm = uriEndpoint.getClass().getDeclaredMethod("toExternalForm");
+            toExternalForm.setAccessible(true);
+            return (String) toExternalForm.invoke(uriEndpoint);
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientRedirectWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientRedirectWrapper.java
@@ -13,13 +13,10 @@ import java.lang.reflect.Method;
 import java.net.URL;
 
 public class SpringWebClientRedirectWrapper implements Wrapper {
-    // Package-private in Reactor Netty, referenced by name only. This is the internal method
-    // that runs once per redirect hop, for both WebClient and the Netty-backed RestClient -
-    // Spring's own request-adaptation layer (ExchangeFunction/ReactorClientHttpRequest) is
-    // only invoked once per top-level call and never sees redirect targets for bodiless (e.g.
-    // GET) requests, since Reactor Netty resends internally without going back through it.
-    // Mirrors HttpConnectionRedirectWrapper, which hooks the JDK's equally-internal
-    // followRedirect0 for the same reason.
+    // Package-private in Reactor Netty, referenced by name only. Spring's own layer
+    // (ExchangeFunction) never sees redirect targets for bodiless requests - Reactor Netty
+    // resends internally without going back through it - so this internal method is the only
+    // place redirects are visible. Mirrors HttpConnectionRedirectWrapper's followRedirect0 hook.
     private static final String HTTP_CLIENT_HANDLER_CLASS_NAME =
             "reactor.netty.http.client.HttpClientConnect$HttpClientHandler";
 
@@ -38,9 +35,8 @@ public class SpringWebClientRedirectWrapper implements Wrapper {
     public static class RedirectAdvice {
         @Advice.OnMethodExit(suppress = Throwable.class)
         public static void after(@Advice.This Object handler) throws Exception {
-            // fromURI/toURI are UriEndpoint (also package-private), both reassigned by
-            // redirect() before this advice runs: fromURI is the hostname that redirected,
-            // toURI is where it redirected to.
+            // fromURI/toURI (package-private UriEndpoint fields) are reassigned by redirect()
+            // right before this runs: fromURI is the origin, toURI the redirect target.
             String origin = externalForm(handler, "fromURI");
             String dest = externalForm(handler, "toURI");
             if (origin == null || dest == null) {

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
@@ -1,0 +1,48 @@
+package dev.aikido.agent.wrappers.spring;
+
+import dev.aikido.agent.wrappers.Wrapper;
+import dev.aikido.agent_api.collectors.URLCollector;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.springframework.web.reactive.function.client.ClientRequest;
+
+import java.net.MalformedURLException;
+
+public class SpringWebClientWrapper implements Wrapper {
+    // Referenced by name (not by .class) in the matchers below: ExchangeFunction is only on
+    // the target application's classloader (spring-webflux is compileOnly here), not on the
+    // agent's own classloader, so a .class literal would throw NoClassDefFoundError at premain.
+    private static final String EXCHANGE_FUNCTION_CLASS_NAME =
+            "org.springframework.web.reactive.function.client.ExchangeFunction";
+
+    public String getName() {
+        // Wrap exchange(ClientRequest) on ExchangeFunction, the interface every WebClient
+        // request goes through before Reactor Netty resolves/connects.
+        // https://docs.spring.io/spring-framework/docs/5.3.20/javadoc-api/org/springframework/web/reactive/function/client/ExchangeFunction.html
+        return SpringWebClientAdvice.class.getName();
+    }
+    public ElementMatcher<? super MethodDescription> getMatcher() {
+        return ElementMatchers.isDeclaredBy(getTypeMatcher())
+                .and(ElementMatchers.named("exchange"));
+    }
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return ElementMatchers.hasSuperType(ElementMatchers.named(EXCHANGE_FUNCTION_CLASS_NAME));
+    }
+    public static class SpringWebClientAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public static void before(
+                @Advice.Argument(0) ClientRequest request
+        ) throws MalformedURLException {
+            if (request == null || request.url() == null) {
+                return;
+            }
+            // Report the URL before the request is sent, so DNSRecordCollector can match the
+            // DNS lookup that follows to this outgoing request.
+            URLCollector.report(request.url().toURL());
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
@@ -12,16 +12,14 @@ import org.springframework.web.reactive.function.client.ClientRequest;
 import java.net.MalformedURLException;
 
 public class SpringWebClientWrapper implements Wrapper {
-    // Referenced by name (not by .class) in the matchers below: ExchangeFunction is only on
-    // the target application's classloader (spring-webflux is compileOnly here), not on the
-    // agent's own classloader, so a .class literal would throw NoClassDefFoundError at premain.
+    // Referenced by name, not .class: spring-webflux is compileOnly, so a .class literal would
+    // throw NoClassDefFoundError on the agent's own classloader at premain.
     private static final String EXCHANGE_FUNCTION_CLASS_NAME =
             "org.springframework.web.reactive.function.client.ExchangeFunction";
 
     public String getName() {
-        // Wrap exchange(ClientRequest) on ExchangeFunction, the interface every WebClient
-        // request goes through before Reactor Netty resolves/connects.
-        // https://docs.spring.io/spring-framework/docs/5.3.20/javadoc-api/org/springframework/web/reactive/function/client/ExchangeFunction.html
+        // exchange(ClientRequest) is the interface every WebClient request goes through before
+        // Reactor Netty resolves/connects.
         return SpringWebClientAdvice.class.getName();
     }
     public ElementMatcher<? super MethodDescription> getMatcher() {
@@ -40,8 +38,7 @@ public class SpringWebClientWrapper implements Wrapper {
             if (request == null || request.url() == null) {
                 return;
             }
-            // Report the URL before the request is sent, so DNSRecordCollector can match the
-            // DNS lookup that follows to this outgoing request.
+            // Register before sending, so DNSRecordCollector can match the DNS lookup that follows.
             URLCollector.report(request.url().toURL());
         }
     }

--- a/agent_api/build.gradle
+++ b/agent_api/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     testImplementation 'org.springframework:spring-web:5.3.20'
     testImplementation 'org.springframework:spring-webmvc:5.3.20'
     testImplementation 'org.springframework:spring-test:5.3.20'
+    // Spring WebFlux for WebClient
+    testImplementation 'org.springframework:spring-webflux:5.3.20'
+    testImplementation 'io.projectreactor.netty:reactor-netty-http:1.2.1'
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -12,6 +12,7 @@ import dev.aikido.agent_api.vulnerabilities.outbound_blocking.BlockedOutboundExc
 import dev.aikido.agent_api.vulnerabilities.ssrf.SSRFException;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
+import dev.aikido.agent_api.vulnerabilities.ssrf.IsPrivateIP;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFDetector;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFException;
 
@@ -26,30 +27,46 @@ import static dev.aikido.agent_api.storage.AttackQueue.attackDetected;
 public final class DNSRecordCollector {
     private DNSRecordCollector() {}
     private static final Logger logger = LogManager.getLogger(DNSRecordCollector.class);
-    private static final String OPERATION_NAME = "java.net.InetAddress.getAllByName";
+    private static final String INET_ADDRESS_OPERATION_NAME = "java.net.InetAddress.getAllByName";
+    private static final String SOCKET_CHANNEL_OPERATION_NAME = "java.nio.channels.SocketChannel.connect";
+
     public static void report(String hostname, InetAddress[] inetAddresses) {
+        // InetAddress.getAllByName() resolves everything in one call, so it's safe to consume.
+        process(hostname, inetAddresses, PendingHostnamesStore.getAndRemove(hostname), INET_ADDRESS_OPERATION_NAME);
+    }
+
+    // For clients that resolve their own DNS (e.g. Reactor Netty, used by Spring's WebClient) or
+    // connect straight to an IP literal. A single request can trigger multiple connect() calls to
+    // the same hostname (IPv4 then IPv6), so unlike report(), this peeks the pending port instead
+    // of consuming it - consuming on the first attempt would let a later attempt bypass SSRF.
+    public static void reportConnect(String hostname, InetAddress resolvedAddress) {
+        process(hostname, new InetAddress[]{resolvedAddress}, PendingHostnamesStore.getPorts(hostname), SOCKET_CHANNEL_OPERATION_NAME);
+    }
+
+    private static void process(String hostname, InetAddress[] inetAddresses, Set<Integer> ports, String operationName) {
         try {
             logger.trace("DNSRecordCollector called with %s & inet addresses: %s", hostname, List.of(inetAddresses));
 
             // store stats
-            StatisticsStore.registerCall("java.net.InetAddress.getAllByName", OperationKind.OUTGOING_HTTP_OP);
+            StatisticsStore.registerCall(operationName, OperationKind.OUTGOING_HTTP_OP);
 
-            // Consume pending ports recorded by URLCollector for this hostname.
-            // Removing them here ensures each (hostname, port) pair is counted exactly once.
-            Set<Integer> ports = PendingHostnamesStore.getAndRemove(hostname);
-            if (!ports.isEmpty()) {
-                for (int port : ports) {
-                    HostnamesStore.incrementHits(hostname, port);
+            // No pending port + private IP literal = infrastructure noise (Netty resolver bootstrap
+            // etc), not a real request - skip recording/blocking. SSRF checks below still run regardless.
+            if (!ports.isEmpty() || !IsPrivateIP.isPrivateIp(hostname)) {
+                if (!ports.isEmpty()) {
+                    for (int port : ports) {
+                        HostnamesStore.incrementHits(hostname, port);
+                    }
+                } else {
+                    // We still need to report a hit to the hostname for outbound domain blocking
+                    HostnamesStore.incrementHits(hostname, 0);
                 }
-            } else {
-                // We still need to report a hit to the hostname for outbound domain blocking
-                HostnamesStore.incrementHits(hostname, 0);
-            }
 
-            // Block if the hostname is in the blocked domains list
-            if (ServiceConfigStore.shouldBlockOutgoingRequest(hostname)) {
-                logger.debug("Blocking DNS lookup for domain: %s", hostname);
-                throw BlockedOutboundException.get();
+                // Block if the hostname is in the blocked domains list
+                if (ServiceConfigStore.shouldBlockOutgoingRequest(hostname)) {
+                    logger.debug("Blocking DNS lookup for domain: %s", hostname);
+                    throw BlockedOutboundException.get();
+                }
             }
 
             // Convert inetAddresses array to a List of IP strings :
@@ -62,7 +79,7 @@ public final class DNSRecordCollector {
             for (int port : ports) {
                 logger.debug("Hostname: %s, Port: %s, IPs: %s", hostname, port, ipAddresses);
 
-                Attack attack = SSRFDetector.run(hostname, port, ipAddresses, OPERATION_NAME);
+                Attack attack = SSRFDetector.run(hostname, port, ipAddresses, operationName);
                 if (attack == null) {
                     continue;
                 }
@@ -81,7 +98,7 @@ public final class DNSRecordCollector {
 
             // We don't need the context object to check for stored ssrf, but we do want to run this after our other
             // SSRF checks, making sure if it's a normal ssrf attack it gets reported like that.
-            Attack storedSsrfAttack = new StoredSSRFDetector().run(hostname, ipAddresses, OPERATION_NAME);
+            Attack storedSsrfAttack = new StoredSSRFDetector().run(hostname, ipAddresses, operationName);
             if (storedSsrfAttack != null) {
                 attackDetected(storedSsrfAttack, Context.get());
 

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
@@ -4,17 +4,12 @@ import java.util.*;
 
 /**
  * Thread-local bridge between URLCollector and DNSRecordCollector.
- * URLCollector records hostname+port here; DNSRecordCollector.report() (fed by
- * InetAddress.getAllByName(), which resolves everything in one call) reads and removes the
- * entry so each (hostname, port) pair is processed exactly once per DNS lookup.
- * DNSRecordCollector.reportConnect() (fed by SocketChannel.connect(), which fires once per
- * connect attempt) instead peeks the entry, since a single outbound request can trigger
- * multiple connect attempts to the same hostname (e.g. IPv4 then IPv6 for a dual-stack host).
- *
- * Entries are normally cleared per incoming request by WebRequestCollector, but a peeked
- * entry added outside any incoming-request context (e.g. a WebClient call from a @Scheduled
- * task) would never be cleared that way. Capped at MAX_ENTRIES per thread, evicting the least
- * recently used entry once exceeded, same bounded-LRU pattern as Hostnames.
+ * report() consumes the entry (InetAddress.getAllByName() resolves everything in one call);
+ * reportConnect() peeks it instead, since one request can trigger multiple connect() attempts
+ * to the same hostname (e.g. IPv4 then IPv6) and consuming would skip SSRF on later attempts.
+ * Capped at MAX_ENTRIES per thread with LRU eviction, same pattern as Hostnames - a peeked
+ * entry outside any incoming-request context (e.g. a @Scheduled task) never gets cleared
+ * otherwise.
  */
 public final class PendingHostnamesStore {
     private PendingHostnamesStore() {}

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
@@ -4,14 +4,30 @@ import java.util.*;
 
 /**
  * Thread-local bridge between URLCollector and DNSRecordCollector.
- * URLCollector records hostname+port here; DNSRecordCollector reads and removes the entry
- * so each (hostname, port) pair is processed exactly once per DNS lookup.
+ * URLCollector records hostname+port here; DNSRecordCollector.report() (fed by
+ * InetAddress.getAllByName(), which resolves everything in one call) reads and removes the
+ * entry so each (hostname, port) pair is processed exactly once per DNS lookup.
+ * DNSRecordCollector.reportConnect() (fed by SocketChannel.connect(), which fires once per
+ * connect attempt) instead peeks the entry, since a single outbound request can trigger
+ * multiple connect attempts to the same hostname (e.g. IPv4 then IPv6 for a dual-stack host).
+ *
+ * Entries are normally cleared per incoming request by WebRequestCollector, but a peeked
+ * entry added outside any incoming-request context (e.g. a WebClient call from a @Scheduled
+ * task) would never be cleared that way. Capped at MAX_ENTRIES per thread, evicting the least
+ * recently used entry once exceeded, same bounded-LRU pattern as Hostnames.
  */
 public final class PendingHostnamesStore {
     private PendingHostnamesStore() {}
 
+    private static final int MAX_ENTRIES = 1000;
+
     private static final ThreadLocal<Map<String, Set<Integer>>> store =
-            ThreadLocal.withInitial(LinkedHashMap::new);
+            ThreadLocal.withInitial(() -> new LinkedHashMap<>(16, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, Set<Integer>> eldest) {
+                    return size() > MAX_ENTRIES;
+                }
+            });
 
     public static void add(String hostname, int port) {
         Map<String, Set<Integer>> map = store.get();

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -228,9 +228,7 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testPrivateIpLiteralWithNoPendingPortNotRecorded() {
-        // No pending port and the hostname is a private IP literal: infrastructure noise
-        // (e.g. Reactor Netty's resolver bootstrap resolving nameserver/bind addresses).
-        // Must not be recorded as an outbound hostname.
+        // Looks like infra noise (e.g. Reactor Netty's resolver bootstrap).
         Context.set(null);
         DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2});
         assertEquals(0, HostnamesStore.getHostnamesAsList().length);
@@ -238,8 +236,7 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testPrivateIpLiteralWithNoPendingPortNotBlockedInLockdown() {
-        // Lockdown mode (blockNewOutgoingRequests=true) must not block a private IP literal
-        // that has no pending port, otherwise it would break internal/infra resolutions.
+        // Must not break internal/infra resolutions even in lockdown mode.
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
             true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
         ));
@@ -252,9 +249,7 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testPrivateIpLiteralWithPendingPortStillRecordedAndBlockedInLockdown() {
-        // A private IP literal that DOES have a pending port came from a real outgoing
-        // request made through an instrumented client, not from infrastructure noise. It
-        // must still be recorded and still be subject to outbound blocking in lockdown mode.
+        // A pending port means a real request, not infra noise - still blocked in lockdown.
         ServiceConfigStore.updateFromAPIResponse(new APIResponse(
             true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
         ));
@@ -268,10 +263,7 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testSsrfStillDetectedForPrivateIpLiteralWithPendingPort() {
-        // Regression test: an attacker-supplied private IP literal (e.g. a webhook URL field
-        // pointing straight at 169.254.169.254) reaching a real outgoing request through an
-        // instrumented client must still be caught as SSRF. Earlier attempts at filtering
-        // private IP literals used an early return that accidentally skipped this check.
+        // Regression test for #310: its early return for the infra-noise case also skipped SSRF.
         ServiceConfigStore.updateBlocking(true);
         PendingHostnamesStore.add("169.254.169.254", 80);
         Context.set(new EmptySampleContextObject("http://169.254.169.254:80/latest/meta-data/"));
@@ -282,9 +274,7 @@ public class DNSRecordCollectorTest {
         assertEquals("Aikido Zen has blocked a server-side request forgery", exception.getMessage());
     }
 
-    // reportConnect(): used by SocketChannelWrapper for clients that resolve their own DNS
-    // (e.g. Reactor Netty, used by Spring's WebClient) instead of InetAddress.getAllByName(),
-    // reporting one resolved address per connect() attempt.
+    // reportConnect(): used by SocketChannelWrapper, one resolved address per connect() attempt.
 
     @Test
     public void testReportConnectRecordsHostnameWithPendingPort() {
@@ -300,18 +290,13 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testReportConnectDoesNotConsumePendingPort() {
-        // Unlike report(), reportConnect() must peek instead of consume: a single outbound
-        // request can trigger multiple connect() calls to the same hostname (e.g. trying the
-        // IPv4 then the IPv6 address of a dual-stack host), and each one must still see the
-        // pending port to be checked correctly.
+        // Unlike report(), must peek not consume - a dual-stack host connects twice (IPv4 then IPv6).
         PendingHostnamesStore.add("example.com", 443);
         Context.set(mock(ContextObject.class));
 
         DNSRecordCollector.reportConnect("example.com", inetAddress1);
         assertFalse(PendingHostnamesStore.getPorts("example.com").isEmpty());
 
-        // A second connect attempt (e.g. the IPv6 address) still sees the same pending port
-        // and records another hit, instead of falling back to port 0 or being skipped.
         DNSRecordCollector.reportConnect("example.com", inetAddress2);
         Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
         assertEquals(1, entries.length);
@@ -322,11 +307,8 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testSsrfDetectedOnEveryConnectAttemptForDualStackHostname() throws UnknownHostException {
-        // Regression test for a real bug found via e2e testing: "localhost" resolves to both
-        // 127.0.0.1 and ::1, and Reactor Netty tries both addresses via separate connect()
-        // calls. With a naive getAndRemove() the first attempt would consume the pending port
-        // and the second attempt would silently skip the SSRF check, letting the request
-        // through despite the first attempt having been blocked.
+        // Regression test (found via e2e): a naive getAndRemove() let the second (IPv6) connect
+        // attempt for "localhost" bypass SSRF after the first (IPv4) attempt consumed the port.
         InetAddress loopbackIPv6 = InetAddress.getByName("::1");
         ServiceConfigStore.updateBlocking(true);
         PendingHostnamesStore.add("localhost", 5000);
@@ -342,9 +324,7 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testReportConnectPrivateIpLiteralWithNoPendingPortNotRecorded() {
-        // Same private-IP-literal infrastructure-noise filtering as report(), but for the
-        // reportConnect() path: a literal IP with no pending port (e.g. a raw socket connect
-        // Reactor Netty makes that we never asked for) must not be recorded.
+        // Same infra-noise filtering as report(), for the reportConnect() path.
         Context.set(null);
         DNSRecordCollector.reportConnect("10.20.11.143", inetAddress2);
         assertEquals(0, HostnamesStore.getHostnamesAsList().length);
@@ -362,14 +342,10 @@ public class DNSRecordCollectorTest {
 
     @Test
     public void testSsrfDetectedForRedirectToPrivateIp() throws Exception {
-        // Regression test: a WebClient call to a user-supplied, safe-looking URL that redirects
-        // to a private IP must still be caught, even though the redirect target itself never
-        // has a pending port (SpringWebClientWrapper only sees the original request).
-        // RedirectCollector.report() (called by SpringWebClientRedirectWrapper for each redirect
-        // hop) records the chain so SSRFDetector's PrivateIPRedirectFinder fallback can trace the
-        // private-IP target back to the tainted origin.
-        // Uses attacker-supplied.test rather than example.com since EmptySampleContextObject's
-        // own server URL defaults to example.com, which would collide with the origin hostname.
+        // Redirect targets never get a pending port directly; PrivateIPRedirectFinder traces
+        // back to the tainted origin via the chain RedirectCollector.report() records.
+        // attacker-supplied.test, not example.com: EmptySampleContextObject's own URL defaults
+        // to example.com, which would collide with the origin hostname here.
         ServiceConfigStore.updateBlocking(true);
         PendingHostnamesStore.add("attacker-supplied.test", 80);
         Context.set(new EmptySampleContextObject("http://attacker-supplied.test/redirect-me"));

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -3,6 +3,7 @@ package collectors;
 import dev.aikido.agent_api.background.cloud.api.APIResponse;
 import dev.aikido.agent_api.background.cloud.api.events.DetectedAttack;
 import dev.aikido.agent_api.collectors.DNSRecordCollector;
+import dev.aikido.agent_api.collectors.RedirectCollector;
 import dev.aikido.agent_api.context.Context;
 import dev.aikido.agent_api.context.ContextObject;
 import dev.aikido.agent_api.storage.AttackQueue;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.*;
 import utils.EmptySampleContextObject;
 
 import java.net.InetAddress;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -222,5 +224,167 @@ public class DNSRecordCollectorTest {
             DNSRecordCollector.report("metadata.goog", new InetAddress[]{imdsAddress1, inetAddress2});
             DNSRecordCollector.report("metadata.google.internal", new InetAddress[]{imdsAddress1, inetAddress2});
         });
+    }
+
+    @Test
+    public void testPrivateIpLiteralWithNoPendingPortNotRecorded() {
+        // No pending port and the hostname is a private IP literal: infrastructure noise
+        // (e.g. Reactor Netty's resolver bootstrap resolving nameserver/bind addresses).
+        // Must not be recorded as an outbound hostname.
+        Context.set(null);
+        DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2});
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPrivateIpLiteralWithNoPendingPortNotBlockedInLockdown() {
+        // Lockdown mode (blockNewOutgoingRequests=true) must not block a private IP literal
+        // that has no pending port, otherwise it would break internal/infra resolutions.
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        Context.set(null);
+        assertDoesNotThrow(() ->
+            DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2})
+        );
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPrivateIpLiteralWithPendingPortStillRecordedAndBlockedInLockdown() {
+        // A private IP literal that DOES have a pending port came from a real outgoing
+        // request made through an instrumented client, not from infrastructure noise. It
+        // must still be recorded and still be subject to outbound blocking in lockdown mode.
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        PendingHostnamesStore.add("10.20.11.143", 443);
+        Context.set(mock(ContextObject.class));
+
+        assertThrows(BlockedOutboundException.class, () ->
+            DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2})
+        );
+    }
+
+    @Test
+    public void testSsrfStillDetectedForPrivateIpLiteralWithPendingPort() {
+        // Regression test: an attacker-supplied private IP literal (e.g. a webhook URL field
+        // pointing straight at 169.254.169.254) reaching a real outgoing request through an
+        // instrumented client must still be caught as SSRF. Earlier attempts at filtering
+        // private IP literals used an early return that accidentally skipped this check.
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.add("169.254.169.254", 80);
+        Context.set(new EmptySampleContextObject("http://169.254.169.254:80/latest/meta-data/"));
+
+        Exception exception = assertThrows(SSRFException.class, () ->
+            DNSRecordCollector.report("169.254.169.254", new InetAddress[]{imdsAddress1})
+        );
+        assertEquals("Aikido Zen has blocked a server-side request forgery", exception.getMessage());
+    }
+
+    // reportConnect(): used by SocketChannelWrapper for clients that resolve their own DNS
+    // (e.g. Reactor Netty, used by Spring's WebClient) instead of InetAddress.getAllByName(),
+    // reporting one resolved address per connect() attempt.
+
+    @Test
+    public void testReportConnectRecordsHostnameWithPendingPort() {
+        PendingHostnamesStore.add("example.com", 443);
+        Context.set(mock(ContextObject.class));
+
+        DNSRecordCollector.reportConnect("example.com", inetAddress1);
+        Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
+        assertEquals(1, entries.length);
+        assertEquals("example.com", entries[0].getHostname());
+        assertEquals(443, entries[0].getPort());
+    }
+
+    @Test
+    public void testReportConnectDoesNotConsumePendingPort() {
+        // Unlike report(), reportConnect() must peek instead of consume: a single outbound
+        // request can trigger multiple connect() calls to the same hostname (e.g. trying the
+        // IPv4 then the IPv6 address of a dual-stack host), and each one must still see the
+        // pending port to be checked correctly.
+        PendingHostnamesStore.add("example.com", 443);
+        Context.set(mock(ContextObject.class));
+
+        DNSRecordCollector.reportConnect("example.com", inetAddress1);
+        assertFalse(PendingHostnamesStore.getPorts("example.com").isEmpty());
+
+        // A second connect attempt (e.g. the IPv6 address) still sees the same pending port
+        // and records another hit, instead of falling back to port 0 or being skipped.
+        DNSRecordCollector.reportConnect("example.com", inetAddress2);
+        Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
+        assertEquals(1, entries.length);
+        assertEquals("example.com", entries[0].getHostname());
+        assertEquals(443, entries[0].getPort());
+        assertEquals(2, entries[0].getHits());
+    }
+
+    @Test
+    public void testSsrfDetectedOnEveryConnectAttemptForDualStackHostname() throws UnknownHostException {
+        // Regression test for a real bug found via e2e testing: "localhost" resolves to both
+        // 127.0.0.1 and ::1, and Reactor Netty tries both addresses via separate connect()
+        // calls. With a naive getAndRemove() the first attempt would consume the pending port
+        // and the second attempt would silently skip the SSRF check, letting the request
+        // through despite the first attempt having been blocked.
+        InetAddress loopbackIPv6 = InetAddress.getByName("::1");
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.add("localhost", 5000);
+        Context.set(new EmptySampleContextObject("http://localhost:5000"));
+
+        assertThrows(SSRFException.class, () ->
+            DNSRecordCollector.reportConnect("localhost", inetAddress2) // 127.0.0.1
+        );
+        assertThrows(SSRFException.class, () ->
+            DNSRecordCollector.reportConnect("localhost", loopbackIPv6) // ::1
+        );
+    }
+
+    @Test
+    public void testReportConnectPrivateIpLiteralWithNoPendingPortNotRecorded() {
+        // Same private-IP-literal infrastructure-noise filtering as report(), but for the
+        // reportConnect() path: a literal IP with no pending port (e.g. a raw socket connect
+        // Reactor Netty makes that we never asked for) must not be recorded.
+        Context.set(null);
+        DNSRecordCollector.reportConnect("10.20.11.143", inetAddress2);
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testReportConnectStoredSsrfStillRunsUnconditionally() {
+        ServiceConfigStore.updateBlocking(true);
+        Context.set(null);
+
+        assertThrows(StoredSSRFException.class, () ->
+            DNSRecordCollector.reportConnect("dev.aikido", imdsAddress1)
+        );
+    }
+
+    @Test
+    public void testSsrfDetectedForRedirectToPrivateIp() throws Exception {
+        // Regression test: a WebClient call to a user-supplied, safe-looking URL that redirects
+        // to a private IP must still be caught, even though the redirect target itself never
+        // has a pending port (SpringWebClientWrapper only sees the original request).
+        // RedirectCollector.report() (called by SpringWebClientRedirectWrapper for each redirect
+        // hop) records the chain so SSRFDetector's PrivateIPRedirectFinder fallback can trace the
+        // private-IP target back to the tainted origin.
+        // Uses attacker-supplied.test rather than example.com since EmptySampleContextObject's
+        // own server URL defaults to example.com, which would collide with the origin hostname.
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.add("attacker-supplied.test", 80);
+        Context.set(new EmptySampleContextObject("http://attacker-supplied.test/redirect-me"));
+
+        RedirectCollector.report(
+            new URL("http://attacker-supplied.test/redirect-me"),
+            new URL("http://169.254.169.254/latest/meta-data/")
+        );
+
+        InetAddress imdsResolved = InetAddress.getByAddress(
+            "169.254.169.254", new byte[]{(byte) 169, (byte) 254, (byte) 169, (byte) 254});
+
+        Exception exception = assertThrows(SSRFException.class, () ->
+            DNSRecordCollector.reportConnect("169.254.169.254", imdsResolved)
+        );
+        assertEquals("Aikido Zen has blocked a server-side request forgery", exception.getMessage());
     }
 }

--- a/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
+++ b/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
@@ -33,10 +33,8 @@ public class PendingHostnamesStoreTest {
 
     @Test
     public void testUnboundedHostnamesDoNotGrowThreadLocalMapForever() {
-        // Regression test: entries added outside any incoming-request context (e.g. a
-        // WebClient call from a @Scheduled task) never get cleared by WebRequestCollector's
-        // per-request clear(). Adding well over the internal cap of distinct hostnames must
-        // not let the store grow unboundedly - the oldest, untouched entries get evicted.
+        // Entries outside an incoming-request context (e.g. a @Scheduled task) never get
+        // cleared otherwise - the oldest, untouched ones must get evicted instead.
         for (int i = 0; i < 2000; i++) {
             PendingHostnamesStore.add("host-" + i + ".example.com", 443);
         }
@@ -51,10 +49,8 @@ public class PendingHostnamesStoreTest {
 
     @Test
     public void testReadingAnEntryProtectsItFromEvictionWhileStillInUse() {
-        // A dual-stack connect sequence peeks the same hostname's entry more than once (e.g.
-        // IPv4 then IPv6 attempt), realistically with only a handful of unrelated hostnames
-        // registered on the same thread in between (well under the eviction cap) - not
-        // thousands. Each read counts as "recently used", so the entry survives that window.
+        // A dual-stack connect sequence peeks the same entry twice; each read must count as
+        // "recently used" so it survives unrelated hostnames being added in between.
         PendingHostnamesStore.add("dual-stack.example.com", 443);
 
         for (int i = 0; i < 10; i++) {

--- a/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
+++ b/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
@@ -1,0 +1,81 @@
+package storage;
+
+import dev.aikido.agent_api.storage.PendingHostnamesStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PendingHostnamesStoreTest {
+    @AfterEach
+    public void cleanup() {
+        PendingHostnamesStore.clear();
+    }
+
+    @Test
+    public void testGetPortsDoesNotRemoveEntry() {
+        PendingHostnamesStore.add("dev.aikido", 443);
+
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("dev.aikido"));
+        // Reading again still sees it: getPorts() peeks, it doesn't consume.
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("dev.aikido"));
+    }
+
+    @Test
+    public void testGetAndRemoveConsumesEntry() {
+        PendingHostnamesStore.add("dev.aikido", 443);
+
+        assertEquals(Set.of(443), PendingHostnamesStore.getAndRemove("dev.aikido"));
+        assertTrue(PendingHostnamesStore.getAndRemove("dev.aikido").isEmpty());
+    }
+
+    @Test
+    public void testUnboundedHostnamesDoNotGrowThreadLocalMapForever() {
+        // Regression test: entries added outside any incoming-request context (e.g. a
+        // WebClient call from a @Scheduled task) never get cleared by WebRequestCollector's
+        // per-request clear(). Adding well over the internal cap of distinct hostnames must
+        // not let the store grow unboundedly - the oldest, untouched entries get evicted.
+        for (int i = 0; i < 2000; i++) {
+            PendingHostnamesStore.add("host-" + i + ".example.com", 443);
+        }
+
+        // The very first hostnames added, never read again, must have been evicted.
+        assertTrue(PendingHostnamesStore.getPorts("host-0.example.com").isEmpty());
+        assertTrue(PendingHostnamesStore.getPorts("host-1.example.com").isEmpty());
+
+        // The most recently added hostnames must still be present.
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("host-1999.example.com"));
+    }
+
+    @Test
+    public void testReadingAnEntryProtectsItFromEvictionWhileStillInUse() {
+        // A dual-stack connect sequence peeks the same hostname's entry more than once (e.g.
+        // IPv4 then IPv6 attempt), realistically with only a handful of unrelated hostnames
+        // registered on the same thread in between (well under the eviction cap) - not
+        // thousands. Each read counts as "recently used", so the entry survives that window.
+        PendingHostnamesStore.add("dual-stack.example.com", 443);
+
+        for (int i = 0; i < 10; i++) {
+            PendingHostnamesStore.add("host-" + i + ".example.com", 443);
+        }
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("dual-stack.example.com"));
+
+        for (int i = 10; i < 20; i++) {
+            PendingHostnamesStore.add("host-" + i + ".example.com", 443);
+        }
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("dual-stack.example.com"));
+    }
+
+    @Test
+    public void testClearRemovesEverything() {
+        PendingHostnamesStore.add("dev.aikido", 443);
+        PendingHostnamesStore.add("dev.aikido.not", 80);
+
+        PendingHostnamesStore.clear();
+
+        assertTrue(PendingHostnamesStore.getPorts("dev.aikido").isEmpty());
+        assertTrue(PendingHostnamesStore.getPorts("dev.aikido.not").isEmpty());
+    }
+}

--- a/agent_api/src/test/java/wrappers/WebClientTest.java
+++ b/agent_api/src/test/java/wrappers/WebClientTest.java
@@ -21,14 +21,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * SpringWebClientWrapper (URLCollector.report on ExchangeFunction.exchange) and
- * SocketChannelWrapper (DNSRecordCollector.reportConnect on SocketChannel.connect) run on
- * different threads for a real WebClient call: the former on the subscribing thread, the
- * latter on Reactor Netty's own event-loop thread. PendingHostnamesStore/Context are
- * ThreadLocal, so a plain "Context.set() then webClient.block()" test can't observe both
- * halves together the way HttpURLConnectionTest can for a same-thread blocking client - that
- * only works in production because a real WebFlux request stays on one reactor-http-nio
- * thread throughout. So this file tests each wrapper's own contribution separately.
+ * SpringWebClientWrapper and SocketChannelWrapper fire on different threads for a real
+ * WebClient call (subscribing thread vs. Reactor Netty's event loop), and
+ * PendingHostnamesStore/Context are ThreadLocal - so unlike HttpURLConnectionTest, this can't
+ * be one cohesive test. Each wrapper's contribution is tested separately instead.
  */
 public class WebClientTest {
     private static final WebClient webClient = WebClient.create();
@@ -49,8 +45,6 @@ public class WebClientTest {
 
     @Test
     public void testSpringWebClientWrapperRegistersPendingPort() {
-        // ExchangeFunction.exchange() runs on the subscribing thread, same as this test -
-        // confirms SpringWebClientWrapper fires and calls URLCollector.report() correctly.
         assertTrue(PendingHostnamesStore.getPorts("aikido.dev").isEmpty());
 
         webClient.get().uri("https://aikido.dev").retrieve().bodyToMono(String.class).block();
@@ -60,16 +54,11 @@ public class WebClientTest {
 
     @Test
     public void testSocketChannelWrapperBlocksSsrf() throws Exception {
-        // SocketChannel.connect() is synchronous and single-threaded regardless of caller, so
-        // this exercises SocketChannelWrapper + DNSRecordCollector.reportConnect's real SSRF
-        // logic deterministically, without Reactor's thread-hopping.
         ServiceConfigStore.updateBlocking(true);
         PendingHostnamesStore.add("localhost", 5000);
         Context.set(new EmptySampleContextObject("http://localhost:5000"));
 
-        // Built via getByAddress (no lookup, no InetAddressWrapper interception) so the
-        // resolved address reaches SocketChannel.connect() untouched, isolating this test to
-        // SocketChannelWrapper's own behavior.
+        // getByAddress avoids InetAddressWrapper interception, isolating this to SocketChannelWrapper.
         InetAddress resolved = InetAddress.getByAddress("localhost", new byte[]{127, 0, 0, 1});
         InetSocketAddress address = new InetSocketAddress(resolved, 5000);
         try (SocketChannel channel = SocketChannel.open()) {

--- a/agent_api/src/test/java/wrappers/WebClientTest.java
+++ b/agent_api/src/test/java/wrappers/WebClientTest.java
@@ -1,0 +1,80 @@
+package wrappers;
+
+import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.storage.HostnamesStore;
+import dev.aikido.agent_api.storage.PendingHostnamesStore;
+import dev.aikido.agent_api.storage.ServiceConfigStore;
+import dev.aikido.agent_api.vulnerabilities.ssrf.SSRFException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import utils.EmptySampleContextObject;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SpringWebClientWrapper (URLCollector.report on ExchangeFunction.exchange) and
+ * SocketChannelWrapper (DNSRecordCollector.reportConnect on SocketChannel.connect) run on
+ * different threads for a real WebClient call: the former on the subscribing thread, the
+ * latter on Reactor Netty's own event-loop thread. PendingHostnamesStore/Context are
+ * ThreadLocal, so a plain "Context.set() then webClient.block()" test can't observe both
+ * halves together the way HttpURLConnectionTest can for a same-thread blocking client - that
+ * only works in production because a real WebFlux request stays on one reactor-http-nio
+ * thread throughout. So this file tests each wrapper's own contribution separately.
+ */
+public class WebClientTest {
+    private static final WebClient webClient = WebClient.create();
+
+    @AfterEach
+    void cleanup() {
+        Context.set(null);
+        HostnamesStore.clear();
+        PendingHostnamesStore.clear();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        cleanup();
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.clear();
+    }
+
+    @Test
+    public void testSpringWebClientWrapperRegistersPendingPort() {
+        // ExchangeFunction.exchange() runs on the subscribing thread, same as this test -
+        // confirms SpringWebClientWrapper fires and calls URLCollector.report() correctly.
+        assertTrue(PendingHostnamesStore.getPorts("aikido.dev").isEmpty());
+
+        webClient.get().uri("https://aikido.dev").retrieve().bodyToMono(String.class).block();
+
+        assertEquals(Set.of(443), PendingHostnamesStore.getPorts("aikido.dev"));
+    }
+
+    @Test
+    public void testSocketChannelWrapperBlocksSsrf() throws Exception {
+        // SocketChannel.connect() is synchronous and single-threaded regardless of caller, so
+        // this exercises SocketChannelWrapper + DNSRecordCollector.reportConnect's real SSRF
+        // logic deterministically, without Reactor's thread-hopping.
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.add("localhost", 5000);
+        Context.set(new EmptySampleContextObject("http://localhost:5000"));
+
+        // Built via getByAddress (no lookup, no InetAddressWrapper interception) so the
+        // resolved address reaches SocketChannel.connect() untouched, isolating this test to
+        // SocketChannelWrapper's own behavior.
+        InetAddress resolved = InetAddress.getByAddress("localhost", new byte[]{127, 0, 0, 1});
+        InetSocketAddress address = new InetSocketAddress(resolved, 5000);
+        try (SocketChannel channel = SocketChannel.open()) {
+            SSRFException exception = assertThrows(SSRFException.class, () -> channel.connect(address));
+            assertEquals("Aikido Zen has blocked a server-side request forgery", exception.getMessage());
+        }
+    }
+}

--- a/end2end/server/mock_aikido_core.py
+++ b/end2end/server/mock_aikido_core.py
@@ -1,6 +1,6 @@
 import gzip
 
-from flask import Flask, request, jsonify, Response
+from flask import Flask, request, jsonify, Response, redirect
 import sys
 import os
 import json
@@ -143,6 +143,11 @@ def mock_reset():
     global events
     events = [] # Reset events
     return jsonify({})
+
+@app.route('/mock/redirect-to-metadata', methods=['GET'])
+def mock_redirect_to_metadata():
+    # Used to test redirect-based SSRF: a safe-looking URL that redirects to a private IP.
+    return redirect('http://169.254.169.254/latest/meta-data/', code=302)
 
 @app.route('/mock/set_protection', methods=['POST'])
 def mock_set_protection():

--- a/end2end/server/mock_aikido_core.py
+++ b/end2end/server/mock_aikido_core.py
@@ -149,6 +149,14 @@ def mock_redirect_to_metadata():
     # Used to test redirect-based SSRF: a safe-looking URL that redirects to a private IP.
     return redirect('http://169.254.169.254/latest/meta-data/', code=302)
 
+@app.route('/mock/redirect-to-self', methods=['GET'])
+def mock_redirect_to_self():
+    # Same idea as /mock/redirect-to-metadata, but redirects to this server's own address
+    # (a private IP - localhost) instead of the unreachable-in-CI AWS metadata IP, so the
+    # request actually completes with a real 200 when the agent is disabled (required by
+    # test_payloads_safe_vs_unsafe) instead of hanging until timeout.
+    return redirect('http://localhost:5000/mock/reset', code=302)
+
 @app.route('/mock/set_protection', methods=['POST'])
 def mock_set_protection():
     req = request.get_json()

--- a/end2end/server/mock_aikido_core.py
+++ b/end2end/server/mock_aikido_core.py
@@ -151,10 +151,8 @@ def mock_redirect_to_metadata():
 
 @app.route('/mock/redirect-to-self', methods=['GET'])
 def mock_redirect_to_self():
-    # Same idea as /mock/redirect-to-metadata, but redirects to this server's own address
-    # (a private IP - localhost) instead of the unreachable-in-CI AWS metadata IP, so the
-    # request actually completes with a real 200 when the agent is disabled (required by
-    # test_payloads_safe_vs_unsafe) instead of hanging until timeout.
+    # Like /mock/redirect-to-metadata, but redirects to a reachable private IP (itself) so
+    # disabled-agent runs get a real 200 instead of hanging on the unreachable metadata IP.
     return redirect('http://localhost:5000/mock/reset', code=302)
 
 @app.route('/mock/set_protection', methods=['POST'])

--- a/end2end/spring_webflux_postgres.py
+++ b/end2end/spring_webflux_postgres.py
@@ -37,9 +37,7 @@ spring_webflux_postgres_app.add_payload("ssrf",
     unsafe_request=Request("/api/request?url=http://localhost:5000", method='GET')
 )
 
-# WebClient SSRF via redirect: a safe-looking URL that redirects to a private IP. Exercises
-# SpringWebClientRedirectWrapper specifically - without it, the redirect target is invisible to
-# the agent entirely (see PR description for details).
+# WebClient SSRF via redirect: exercises SpringWebClientRedirectWrapper specifically.
 spring_webflux_postgres_app.add_payload("ssrf via redirect",
     safe_request=Request("/api/request/follow-redirects?url=https://aikido.dev/", method='GET'),
     unsafe_request=Request("/api/request/follow-redirects?url=http://localhost:5000/mock/redirect-to-self", method='GET')

--- a/end2end/spring_webflux_postgres.py
+++ b/end2end/spring_webflux_postgres.py
@@ -37,6 +37,14 @@ spring_webflux_postgres_app.add_payload("ssrf",
     unsafe_request=Request("/api/request?url=http://localhost:5000", method='GET')
 )
 
+# WebClient SSRF via redirect: a safe-looking URL that redirects to a private IP. Exercises
+# SpringWebClientRedirectWrapper specifically - without it, the redirect target is invisible to
+# the agent entirely (see PR description for details).
+spring_webflux_postgres_app.add_payload("ssrf via redirect",
+    safe_request=Request("/api/request/follow-redirects?url=https://aikido.dev/", method='GET'),
+    unsafe_request=Request("/api/request/follow-redirects?url=http://localhost:5000/mock/redirect-to-self", method='GET')
+)
+
 spring_webflux_postgres_app.test_all_payloads()
 spring_webflux_postgres_app.test_blocking()
 spring_webflux_postgres_app.test_rate_limiting()

--- a/end2end/spring_webflux_postgres.py
+++ b/end2end/spring_webflux_postgres.py
@@ -30,6 +30,13 @@ spring_webflux_postgres_app.add_payload(
     unsafe_request=Request("/api/commands/executeFromCookie", method='GET', headers={'Cookie': 'command=|sleep;command=|sleep'}),
 )
 
+# WebClient SSRF: query params are the taint source tracked for Spring WebFlux (the request
+# body isn't, see agent_api's SpringWebfluxContextObject).
+spring_webflux_postgres_app.add_payload("ssrf",
+    safe_request=Request("/api/request?url=https://aikido.dev/", method='GET'),
+    unsafe_request=Request("/api/request?url=http://localhost:5000", method='GET')
+)
+
 spring_webflux_postgres_app.test_all_payloads()
 spring_webflux_postgres_app.test_blocking()
 spring_webflux_postgres_app.test_rate_limiting()

--- a/sample-apps/SpringWebfluxSampleApp/src/main/java/dev/aikido/SpringWebfluxSampleApp/RequestController.java
+++ b/sample-apps/SpringWebfluxSampleApp/src/main/java/dev/aikido/SpringWebfluxSampleApp/RequestController.java
@@ -1,0 +1,70 @@
+package dev.aikido.SpringWebfluxSampleApp;
+
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@RestController
+@RequestMapping("/api/request")
+public class RequestController {
+    private record UrlRequest(String url) {}
+
+    private static final WebClient webClient = WebClient.create();
+
+    // A separate client with followRedirect enabled, to exercise SSRF detection across
+    // redirects (see SpringWebClientRedirectWrapper).
+    private static final WebClient webClientFollowingRedirects = WebClient.builder()
+            .clientConnector(new ReactorClientHttpConnector(HttpClient.create().followRedirect(true)))
+            .build();
+
+    @PostMapping
+    public Mono<String> makeRequest(@RequestBody UrlRequest urlRequest) {
+        return makeRequestInternal(urlRequest.url());
+    }
+
+    // Query params are a tracked taint source for Spring WebFlux (unlike the request body),
+    // so this variant is used to exercise SSRF detection end to end.
+    @GetMapping
+    public Mono<String> makeRequestFromQuery(@RequestParam String url) {
+        return makeRequestInternal(url);
+    }
+
+    @GetMapping("/follow-redirects")
+    public Mono<String> makeRequestFollowingRedirects(@RequestParam String url) {
+        return webClientFollowingRedirects.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> isAikidoBlock(e)
+                        ? Mono.error(e)
+                        : Mono.just("Error: " + e.getMessage()));
+    }
+
+    private Mono<String> makeRequestInternal(String url) {
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> isAikidoBlock(e)
+                        ? Mono.error(e)
+                        : Mono.just("Error: " + e.getMessage()));
+    }
+
+    // Aikido Zen blocks (SSRF, outbound blocking, ...) must propagate as a server error
+    // instead of being swallowed into a 200 response, same as any other Aikido block.
+    private static boolean isAikidoBlock(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (cause.getClass().getName().startsWith("dev.aikido.agent_api.vulnerabilities")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Context

Follow-up to #308/#310 (reverted as #311). Customer flood was `InetAddress.getAllByName()` picking up Reactor Netty's own DNS-resolver bootstrap noise (`0.0.0.0`, `::`, `/etc/resolv.conf` nameservers) as "new outbound connections" on port 0, and blocking them in lockdown mode. #310 fixed the flood but did it with an early `return` in `DNSRecordCollector.report()` that also skipped the SSRF check below it — verified with a live regression test that this let an attacker-supplied private-IP literal (e.g. a webhook field pointing straight at `169.254.169.254`) through undetected.

While investigating a better fix, found the actual root cause is bigger: **Spring's `WebClient` was never instrumented at all**, and **Reactor Netty's default HTTP client bypasses `InetAddress.getAllByName()` entirely** (it uses its own async DNS resolver). So even after wrapping WebClient to register pending ports, `DNSRecordCollector` was never invoked for real WebClient targets — confirmed empirically via trace logs against a live running app. WebClient traffic had zero outbound-domain visibility and zero SSRF protection, independent of this bug.

## Review feedback addressed

- **Diff size / comments** — trimmed: reverted the `recordHitAndEnforceBlocklist` extraction back inline, cut comments down to what's non-obvious.
- **`isInfrastructureNoise`/`ports.isEmpty()` reliability** — the original concern was that this check is false-negative prone: a real request could be mistaken for infra noise and slip through unrecorded. That was a real, confirmed gap, not just theoretical.

  `ports.isEmpty()` is only reliable if we correctly register a "pending port" for every request WebClient actually makes. This PR makes sure that happens for both places a request goes out: the initial call, and any redirect Reactor Netty follows on WebClient's behalf (`SpringWebClientRedirectWrapper`) — before this PR, redirect targets registered nothing, so a redirect to a private IP looked exactly like infra noise even though it came from a real request. Both paths are now covered and tested.

  There's a second, separate way this signal can still go missing: WebClient's "register pending port" step and its actual network connect can run on different threads (e.g. if the app switches schedulers before calling WebClient, a common pattern when mixing blocking JDBC with reactive code), and our current bookkeeping is thread-local, so it doesn't survive that. Confirmed this via e2e and are fixing it in follow-up #313 (kept separate since it's an independent, ~300-line change that hasn't been reviewed yet, unlike the rest of this PR).
- **e2e test using WebClient in a Spring app** — added both a JUnit-level test (`WebClientTest`, real network calls, same style as `HttpURLConnectionTest`) and two full e2e payloads in `spring_webflux_postgres.py` (`ssrf`, and `ssrf via redirect` covering the redirect fix specifically). See Tests below.

## Architecture note: this fits the agent's existing two-layer hook pattern, it doesn't add a new one

Every HTTP client the agent tracks is covered by two kinds of hook working together:

1. **A per-client "intent" hook** — one per library, because each has its own API for making a request: `OkHttpWrapper` (`OkHttpClient.newCall`), `ApacheHttpClientWrapper` (`HttpClient.execute`), `HttpClientSendWrapper` (JDK `HttpClient.send`/`sendAsync`), and now `SpringWebClientWrapper` (`ExchangeFunction.exchange`, the Spring-level interface every `WebClient` call goes through, independent of whatever transport it's configured with). All of these just extract host+port and register it via `URLCollector` → `PendingHostnamesStore`.
2. **A shared, client-agnostic "connection" hook** — this is where recording, outbound blocking, and SSRF checks actually happen (`DNSRecordCollector`). Before this PR there was exactly one: `InetAddressWrapper`, hooking the JDK's `InetAddress.getAllByName()`. It's generic — it doesn't know or care which library called it.

OkHttp, Apache HttpClient, and the JDK's own `HttpClient` all resolve DNS through that same standard JDK method, so layer 2 already covered them with no extra work. **`WebClient`'s underlying transport (Reactor Netty) is the one exception**: it deliberately uses its own async DNS resolver instead of `InetAddress.getAllByName()`, so it was invisible to layer 2 no matter how well layer 1 was instrumented.

`SocketChannelWrapper` is **not Netty-specific instrumentation** — it hooks `java.nio.channels.SocketChannel.connect(SocketAddress)`, a standard JDK class, with zero references to any `io.netty.*` type. It catches Reactor Netty as a side effect of Netty's `NioSocketChannel` internally calling this same standard method to open its sockets — the same hook would also catch any other NIO-based client, not just Netty. This is layer 2 gaining a second, complementary entry point, not a new Netty-specific layer.

## What changed

- **`DNSRecordCollector.java`** — private-IP-literal gate narrowed to `ports.isEmpty() && IsPrivateIP.isPrivateIp(hostname)`, only skipping *recording + outbound blocking* (SSRF checks are unconditional again). Deliberately not #310's "just ignore private IPs" — the `ports.isEmpty()` half is what makes it safe: a genuine request through *any* instrumented client always registers a pending port before resolution/connection happens, so this can only ever match traffic with no app-level request behind it (DNS bootstrap, direct-by-IP connects), never a real request, attacker-driven or not.
- **`SpringWebClientWrapper.java`** — new wrapper, hooks `ExchangeFunction.exchange()` (the interface every WebClient request goes through) to register pending host+port via `URLCollector`, same pattern as the existing OkHttp/Apache/JDK `HttpClient` wrappers (layer 1 above).
- **`SocketChannelWrapper.java`** — new wrapper, hooks `java.nio.channels.SocketChannel.connect(SocketAddress)` (layer 2 above). This is what actually closes the gap: it's the JDK-level call every NIO-based client (including Reactor Netty) makes once it has a resolved address, regardless of which DNS resolver produced it, and it also catches literal-IP targets that never go through any resolver at all.
- **`DNSRecordCollector.reportConnect()`** — new entry point used by `SocketChannelWrapper`. Peeks the pending port (`PendingHostnamesStore.getPorts`) instead of consuming it (`report()`'s `getAndRemove`), for a reason specific to this new hook: `report()` (fed by `InetAddress.getAllByName()`) always sees *every* resolved address for a hostname in one call, so it's safe to consume the pending port immediately — the full picture is already known before any connection is attempted. `reportConnect()` (fed by `SocketChannel.connect()`) instead learns about addresses one at a time, exactly when each individual connection attempt happens.

  This matters because of Happy Eyeballs: a dual-stack hostname like `localhost` resolves to both `127.0.0.1` and `::1`, and Netty tries them as **separate, sequential `connect()` calls**, not one combined resolution step. A hostname can resolve to more than 2 addresses in general (multiple A/AAAA records are common for load-balanced services) — Netty will try each one in turn.

  Found live: with a naive `getAndRemove()`, the *first* `connect()` attempt (IPv4) correctly detected and blocked SSRF — but that also consumed the pending port. The *second* attempt (IPv6, same hostname) found nothing pending, so the SSRF check loop didn't run at all, and the connection succeeded — the earlier "block" was logged but had no real effect, because the client just silently retried on the other address family and got through. Fixed by peeking instead of consuming; both attempts are now checked. Covered by `testSsrfDetectedOnEveryConnectAttemptForDualStackHostname`.

- **`NettySocketChannelWrapper.java`** — new wrapper, closing a critical gap found via this PR's own CI runs: `SocketChannelWrapper` hooks `java.nio.channels.SocketChannel` (the JDK type), but Reactor Netty prefers its **native epoll transport** on Linux whenever the native library loads successfully - the common case in production, and exactly why every local run (macOS) passed while every CI run (real Linux) failed the `ssrf` e2e payload 100% of the time. `EpollSocketChannel` implements Netty's *own* `io.netty.channel.socket.SocketChannel` interface instead - structurally unrelated to the JDK type despite the identical simple name - so `SocketChannelWrapper` never saw those connections at all. Confirmed via a temporary diagnostic build before writing the fix: `SocketChannelWrapper`'s advice genuinely never ran for the WebClient request in CI, only for the agent's own JDK-`HttpClient`-based reporting calls. `NettySocketChannelWrapper` instead hooks `doConnect(SocketAddress, SocketAddress)` on any subtype of `io.netty.channel.AbstractChannel` - the low-level entry point every Netty transport implementation overrides (`NioSocketChannel`, `EpollSocketChannel`, `KQueueSocketChannel`), so it fires regardless of which transport gets picked. Verified against a real epoll-active instance (Docker, forced to `linux/amd64` to get the native library to actually load), not just reasoned about - literal-IP, dual-stack, and redirect-based SSRF all correctly blocked, full `spring_webflux_postgres.py` e2e suite passing end to end.
- **`PendingHostnamesStore.java`** — peeking instead of consuming (above) means entries now rely on `WebRequestCollector`'s per-incoming-request `clear()` for cleanup, which never fires for `WebClient` calls made outside any incoming-request context (e.g. a `@Scheduled` background task) — those entries would otherwise sit in that thread's `ThreadLocal` map forever. Capped the store at 1000 entries per thread, evicting the least-recently-used one once exceeded — the same bounded-LRU pattern (`LinkedHashMap` with `accessOrder=true` + `removeEldestEntry()`) already used by `Hostnames.java` for the same class of problem. Deliberately not a time-based TTL: eviction is purely by usage count, not wall-clock time, so it can't interact with the dual-stack fix above (an entry touched by a second connect attempt is safe unless ~1000 unrelated hostnames get registered on the same thread in between, which doesn't happen within one request's connect sequence) — no timing-dependent race, and `add()`/`getAndRemove()`/`getPorts()`/`clear()` stay in their original, simple form. Covered by `PendingHostnamesStoreTest`.

- **`SpringWebClientRedirectWrapper.java`** — new wrapper closing a gap flagged in review: `ports.isEmpty()` isn't a fully reliable signal for "not a real request". Concretely: WebClient configured with `.followRedirect(true)` never re-invokes Spring's request-adaptation layer for redirect hops — Reactor Netty resends bodiless (e.g. GET) requests internally without going back through `ExchangeFunction`/`ReactorClientHttpRequest` — so a redirect to a private IP had no pending port and was invisible to both tracking *and* SSRF, indistinguishable from genuine infra noise even though it originated from a real, tainted request. Hooks the package-private `HttpClientConnect$HttpClientHandler.redirect()` (the only place this is visible, verified by tracing Spring's `send(BiFunction)` callback — it does **not** re-fire per redirect for bodiless requests, contrary to its own javadoc's implication) and feeds the chain into the existing `RedirectCollector`/`PrivateIPRedirectFinder` machinery, the same one already used for JDK `HttpURLConnection` redirects. Mirrors `HttpConnectionRedirectWrapper`'s existing tradeoff of hooking an internal, undocumented method (there: `followRedirect0`) for this exact reason.
- **`RequestController.java`** (SpringWebfluxSampleApp) — `/api/request` endpoint (GET with `url` query param, POST with JSON body) plus a `.followRedirect(true)` variant at `/api/request/follow-redirects`, used to validate all of the above against a real running app, and now wired into `end2end/spring_webflux_postgres.py` as an automated e2e payload.

Also fixed along the way: `SpringWebClientWrapper`'s first version referenced `ExchangeFunction.class` directly in its ByteBuddy matchers, which requires the class to resolve on the *agent's own* classloader at premain — but `spring-webflux` is `compileOnly`, only present on the target app's classloader. This crashed the JVM with `NoClassDefFoundError` at startup for any app using the agent. Fixed with string-based matchers (`hasSuperType(named(...))`), the same pattern `OkHttpWrapper`/`ApacheHttpClientWrapper` already use for third-party types.

## e2e scenarios tested

Built and ran the real agent against a real Spring Boot WebFlux app end to end (not just unit tests):

```bash
# Build agent jars with the changes
./gradlew agent:shadowJar agent_api:shadowJar
cp agent/build/libs/agent*-all.jar dist/agent.jar
cp agent_api/build/libs/agent_api*-all.jar dist/agent_api.jar

# Mock core (captures heartbeat/attack events)
cd end2end/server && docker build -t mock_core . && docker run --name mock_core -d -p 5000:5000 mock_core

# Sample app with the agent attached
cd sample-apps/SpringWebfluxSampleApp && ./gradlew build -x test
AIKIDO_LOG_LEVEL=trace AIKIDO_TOKEN=token AIKIDO_BLOCK=1 \
  AIKIDO_ENDPOINT=http://localhost:5000 AIKIDO_REALTIME_ENDPOINT=http://localhost:5000/realtime \
  java -javaagent:../../dist/agent.jar -jar build/libs/SpringWebfluxSampleApp-0.0.1-SNAPSHOT.jar --server.port=8090
```

1. **App startup didn't crash** — caught the `NoClassDefFoundError` bug this way; unit tests can't catch agent-premain class loading issues.

2. **Real domain via WebClient gets correct port tracking (not port 0):**
   ```bash
   curl -G "http://localhost:8090/api/request" --data-urlencode "url=https://example.com"
   ```
   Log: `DNSRecordCollector called with example.com & inet addresses: [example.com/104.20.23.154]` → `Hostname: example.com, Port: 443` (previously untracked entirely).

3. **SSRF via WebClient, literal private IP, now blocked:**
   ```bash
   curl -G "http://localhost:8090/api/request" --data-urlencode "url=http://169.254.169.254/latest/meta-data/"
   ```
   → HTTP 500, `"Aikido Zen has blocked a server-side request forgery"`. Stack trace confirms interception point: `sun.nio.ch.SocketChannelImpl.connect` ← `NioSocketChannel.doConnect` ← `reactor.netty.transport.TransportConnector`.

4. **SSRF via WebClient, dual-stack hostname (`localhost` → `127.0.0.1` + `::1`), both connect attempts blocked:**
   ```bash
   curl -G "http://localhost:8090/api/request" --data-urlencode "url=http://localhost:5000"
   ```
   → HTTP 500. Before the `reportConnect()` fix, this returned 200 with the mock server's real response — the first (IPv4) attempt was blocked and logged, but the second (IPv6) attempt silently bypassed SSRF because the first had already consumed the pending port.

5. **Private-IP noise from Netty's resolver bootstrap not recorded and not blocked in lockdown** — confirmed via mock server heartbeat: after triggering the bootstrap noise (`0.0.0.0`, `::`, local resolver IP `10.2.0.1`) and a real request, only `localhost:5000` (the agent's own reporting) showed up in reported hostnames.

6. **Safe request to a real public domain still works normally**, HTTP 200, both via WebClient and confirmed no regression for already-instrumented clients.

7. **Redirect-based SSRF via WebClient, now blocked:**
   ```bash
   curl -G "http://localhost:8090/api/request/follow-redirects" --data-urlencode "url=http://localhost:5000/mock/redirect-to-metadata"
   ```
   (mock core's `/mock/redirect-to-metadata` returns a 302 to `http://169.254.169.254/latest/meta-data/`.) → HTTP 500. With `block` temporarily set to detect-only, confirmed the attack event fires specifically for `169.254.169.254:80` with `source=query`, i.e. traced back through the redirect chain to the tainted origin — not just the origin itself being blocked. Before this wrapper, `169.254.169.254` never appeared in any DNSRecordCollector/SSRF log at all despite `SocketChannelWrapper` seeing the actual connect attempt — no pending port meant no taint check.

## Tests

Added to `DNSRecordCollectorTest` (22 tests total in the file now, all passing):
- `testPrivateIpLiteralWithNoPendingPortNotRecorded` / `...NotBlockedInLockdown` — infra noise filtering still works.
- `testPrivateIpLiteralWithPendingPortStillRecordedAndBlockedInLockdown` — real requests to private IPs via instrumented clients are unaffected by the noise filter.
- `testSsrfStillDetectedForPrivateIpLiteralWithPendingPort` — regression test proving the earlier early-return SSRF bypass is fixed.
- `testReportConnectRecordsHostnameWithPendingPort`, `testReportConnectDoesNotConsumePendingPort`, `testReportConnectPrivateIpLiteralWithNoPendingPortNotRecorded`, `testReportConnectStoredSsrfStillRunsUnconditionally` — `reportConnect()` behavior.
- `testSsrfDetectedOnEveryConnectAttemptForDualStackHostname` — regression test for the dual-stack SSRF bypass found during e2e testing.

New `PendingHostnamesStoreTest`:
- `testUnboundedHostnamesDoNotGrowThreadLocalMapForever` — adds 2000 distinct hostnames, confirms the oldest untouched ones are evicted and the store stays bounded.
- `testReadingAnEntryProtectsItFromEvictionWhileStillInUse` — confirms an entry touched by a second connect attempt survives a realistic number of unrelated hostnames being added in between.

New `testSsrfDetectedForRedirectToPrivateIp` in `DNSRecordCollectorTest` — regression test for the redirect gap, exercising `RedirectCollector` + `DNSRecordCollector.reportConnect()` directly.

New `agent_api/src/test/java/wrappers/WebClientTest.java`, mirroring the existing `HttpURLConnectionTest` pattern (real network calls, run with the actual built agent attached via the `agent_api` test task's `-javaagent`) — split into two tests instead of one end-to-end test, because `SpringWebClientWrapper` and `SocketChannelWrapper` fire on different threads for a real WebClient call (the former on the subscribing thread, the latter on Reactor Netty's own event-loop thread), and `PendingHostnamesStore`/`Context` are `ThreadLocal`, so they can't be observed together the way a same-thread blocking client's wrapper can:
- `testSpringWebClientWrapperRegistersPendingPort` — confirms `SpringWebClientWrapper` fires and registers the right port.
- `testSocketChannelWrapperBlocksSsrf` — confirms `SocketChannelWrapper` + `DNSRecordCollector.reportConnect()`'s SSRF logic, via a raw `SocketChannel.connect()` call (single-threaded, deterministic).

New `end2end/spring_webflux_postgres.py` payload: `ssrf`, using the new `/api/request` endpoint, following the same pattern as `javalin_mysql_kotlin.py`'s existing SSRF payload. Ran the full e2e suite (all existing SQL/command-injection/path-traversal/bot/IP-blocking/rate-limiting payloads plus this new one) — all passing, no regressions.

New `end2end/spring_webflux_postgres.py` payload: `ssrf via redirect`, exercising `SpringWebClientRedirectWrapper` through a real HTTP redirect (previously only covered by a JUnit test that calls `RedirectCollector`/`DNSRecordCollector` directly, bypassing the actual redirect mechanics, plus manual curl verification during development - no automated regression coverage existed for this path). Redirects to a new mock server endpoint, `/mock/redirect-to-self`, which redirects back to the mock server's own address rather than the (CI-unreachable) AWS metadata IP used for manual testing - required so the disabled-agent run of the test actually completes with a real 200 instead of hanging until timeout. Ran the full e2e suite locally (with and without the agent) to confirm - all payloads passing, no regressions.

## Known limitations / follow-up worklog (not fixed in this PR)

Tracking known gaps here so we don't lose track between review rounds. None of these are regressions from this PR — they're either pre-existing or newly-discovered-but-out-of-scope.

**Guiding principle:** minimize false negatives. It's fine to keep treating genuine infra noise as noise (e.g. Netty's DNS-resolver bootstrap connecting to `0.0.0.0`/`::`/local resolver on startup — not from app code, correctly dropped today, unrelated to the items below). It is not fine to silently drop a private-IP connection that actually originated from business logic, however indirectly (redirect, scheduler hop, etc).

**Priority order for next steps:** (1) verify `RestClient` instrumentation status; (2) quick verification pass on `IsPrivateIP` exotic-encoding handling; (3) WebFlux body-taint is separate scope, lower priority. (The `ports.isEmpty()` reliability gap and the epoll transport gap, previously listed here, are both resolved — see "Resolved" section below.)

1. **Spring WebFlux has no request-body taint tracking at all** (`SpringWebfluxContextObject` never populates `ContextObject.body`), so SSRF/etc. via JSON body can't be detected for WebFlux apps regardless of this change — that's why the e2e scenarios above use query params instead of body. Pre-existing, not a regression.

2. **Priority: verify before building anything — Spring's `RestClient` (6.1+) instrumentation status is unverified.** `SpringWebClientWrapper` hooks `ExchangeFunction.exchange()`, a WebFlux-specific interface. `RestClient` is built on the older `ClientHttpRequestFactory` abstraction (shared with `RestTemplate`), not `ExchangeFunction`. If `RestClient` is backed by JDK HttpClient or Apache HttpClient (likely default in many setups) it's **already covered** by the existing `HttpClientSendWrapper`/`ApacheHttpClientWrapper` — nothing to do. If backed by Reactor Netty, it bypasses `SpringWebClientWrapper` entirely and needs its own wrapper — same class of bug this whole PR started from, under a different Spring API. This is a missing-hook problem, unrelated to the thread-propagation gap fixed in #313.

3. **Unverified: does `IsPrivateIP.isPrivateIp()` correctly recognize exotic private-IP encodings** (decimal/octal IP literals like `http://2130706433/`, IPv4-mapped IPv6 like `::ffff:127.0.0.1`)? Pre-existing code, not introduced by this PR, and errs safe if it fails (an unrecognized private IP just gets treated as a normal hostname — recorded and blocklist-checked as usual, not silently dropped), but worth a dedicated verification pass given it's a classic SSRF bypass technique.

### Resolved in this PR

~~`SocketChannelWrapper` never fires under Netty's native epoll transport (Linux default)~~ — see `NettySocketChannelWrapper.java` under "What changed" above. This was the one blocking every CI run of this PR's own e2e job, so it had to land here rather than as a follow-up.

### Resolved in a follow-up PR

~~`ports.isEmpty()` is not a fully reliable "did this originate from a real HTTP request" signal~~ — confirmed via e2e (a `/api/request/publish-on` scheduler-hop reproduction: SSRF silently not detected, real network request went out unblocked) and fixed in **#313**, stacked on top of this PR. Kept as a separate PR rather than folded in here since it's an independent, self-contained ~300-line change that hasn't been through review yet, unlike the rest of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
| ⚠️ Security Issues: 7 | 🔍 Quality Issues: 11 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Instrumented Spring WebClient and redirect handling to register requests

**⚡ Enhancements**
* Added SocketChannel.connect hook to report real connect attempts
* Capped PendingHostnamesStore with LRU eviction and added peek support

**🐛 Bugfixes**
* Narrowed DNS recording gate and unconditionally ran SSRF checks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/141143586?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->

