### PR TITLE
Fix ports.isEmpty() reliability gap: make request correlation survive scheduler hops

### DIFF
--- a/agent/src/main/java/dev/aikido/agent/wrappers/HttpClientSendWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/HttpClientSendWrapper.java
@@ -6,7 +6,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
-import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -55,13 +54,9 @@ public class HttpClientSendWrapper implements Wrapper {
             // Load the class from the JAR
             Class<?> clazz = classLoader.loadClass("dev.aikido.agent_api.collectors.URLCollector");
 
-            // Run report with "argument"
-            for (Method method2: clazz.getMethods()) {
-                if(method2.getName().equals("report")) {
-                    method2.invoke(null, httpRequest.uri().toURL());
-                    break;
-                }
-            }
+            // report(URL) is overloaded (also has a report(URL, ContextObject) variant), so it
+            // must be looked up by exact signature - matching by name alone could pick either.
+            clazz.getMethod("report", URL.class).invoke(null, httpRequest.uri().toURL());
             classLoader.close(); // Close the class loader
         }
     }

--- a/agent/src/main/java/dev/aikido/agent/wrappers/HttpURLConnectionWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/HttpURLConnectionWrapper.java
@@ -5,7 +5,6 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
-import java.lang.reflect.Method;
 import java.net.*;
 
 import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
@@ -50,13 +49,9 @@ public class HttpURLConnectionWrapper implements Wrapper {
             // Load the class from the JAR
             Class<?> clazz = classLoader.loadClass("dev.aikido.agent_api.collectors.URLCollector");
 
-            // Run report with "argument"
-            for (Method method2: clazz.getMethods()) {
-                if(method2.getName().equals("report")) {
-                    method2.invoke(null, url);
-                    break;
-                }
-            }
+            // report(URL) is overloaded (also has a report(URL, ContextObject) variant), so it
+            // must be looked up by exact signature - matching by name alone could pick either.
+            clazz.getMethod("report", URL.class).invoke(null, url);
             classLoader.close(); // Close the class loader
         }
     }

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/ReactorAikidoContext.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/ReactorAikidoContext.java
@@ -1,0 +1,91 @@
+package dev.aikido.agent.wrappers.spring;
+
+import dev.aikido.agent_api.collectors.URLCollector;
+import dev.aikido.agent_api.context.ContextObject;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.URL;
+
+/**
+ * Carries the Aikido ContextObject through Reactor's own Context so it survives scheduler hops
+ * (e.g. .publishOn()) between the incoming WebFlux request and any WebClient calls made while
+ * handling it - unlike Context.get()'s ThreadLocal, which only sees the current OS thread.
+ *
+ * Everything here is Object-typed and goes through reflection, rooted at the classloader of a
+ * live Mono instance passed in. reactor-core is compileOnly for this module: a *separate* class
+ * (like this one, as opposed to an @Advice method whose parameter types ByteBuddy resolves
+ * specially against the woven target's own classloader) that declares Mono, Context or
+ * ContextView as a concrete parameter/return type throws NoClassDefFoundError at class
+ * verification time on the agent's own classloader, which has no visibility into the target
+ * application's classpath. Must be public: the woven target class (in a completely different
+ * package) needs to call into it directly.
+ */
+public final class ReactorAikidoContext {
+    private static final String KEY = "dev.aikido.agent.wrappers.spring.ReactorAikidoContextKey";
+
+    private ReactorAikidoContext() {}
+
+    // `mono` is a Mono<Void>, returned Object is that same Mono<Void> wrapped with .contextWrite().
+    public static Object write(Object mono, ContextObject context) {
+        try {
+            ClassLoader cl = mono.getClass().getClassLoader();
+            Class<?> contextClass = Class.forName("reactor.util.context.Context", false, cl);
+            Class<?> contextViewClass = Class.forName("reactor.util.context.ContextView", false, cl);
+            Object newContext = contextClass.getMethod("of", Object.class, Object.class)
+                    .invoke(null, KEY, context);
+            Method contextWrite = mono.getClass().getMethod("contextWrite", contextViewClass);
+            return contextWrite.invoke(mono, newContext);
+        } catch (Throwable t) {
+            return mono;
+        }
+    }
+
+    // `original` is a Mono<T>. Registers `url` once `original` is actually subscribed to, using
+    // whatever ContextObject write() captured upstream in the same reactive chain (null if
+    // none). Returns a Mono<T> equivalent to `original` (or `original` itself if anything here
+    // fails - registration is best-effort, must never break the actual request).
+    public static Object deferRegisterUrl(Object original, URL url) {
+        try {
+            ClassLoader cl = original.getClass().getClassLoader();
+            Class<?> functionClass = Class.forName("java.util.function.Function", false, cl);
+            Method deferContextual = original.getClass().getMethod("deferContextual", functionClass);
+            InvocationHandler handler = new RegisterUrlHandler(original, url);
+            Object proxy = Proxy.newProxyInstance(cl, new Class<?>[]{functionClass}, handler);
+            return deferContextual.invoke(null, proxy);
+        } catch (Throwable t) {
+            return original;
+        }
+    }
+
+    // Not a lambda: constructed from advice code that ByteBuddy inlines into the *target*
+    // class's bytecode, so a lambda here would become a private synthetic method that the
+    // target class can't call back into (IllegalAccessError). A plain named class implementing
+    // InvocationHandler - whose own methods only ever see java.lang.Object - avoids that.
+    private static final class RegisterUrlHandler implements InvocationHandler {
+        private final Object original;
+        private final URL url;
+
+        RegisterUrlHandler(Object original, URL url) {
+            this.original = original;
+            this.url = url;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            if (!"apply".equals(method.getName()) || args == null || args.length == 0) {
+                return original;
+            }
+            Object ctxView = args[0];
+            ContextObject context = null;
+            try {
+                Method getOrDefault = ctxView.getClass().getMethod("getOrDefault", Object.class, Object.class);
+                context = (ContextObject) getOrDefault.invoke(ctxView, KEY, null);
+            } catch (Throwable ignored) {
+            }
+            URLCollector.report(url, context);
+            return original;
+        }
+    }
+}

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebClientWrapper.java
@@ -1,15 +1,17 @@
 package dev.aikido.agent.wrappers.spring;
 
 import dev.aikido.agent.wrappers.Wrapper;
-import dev.aikido.agent_api.collectors.URLCollector;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.publisher.Mono;
 
 import java.net.MalformedURLException;
+import java.net.URL;
 
 public class SpringWebClientWrapper implements Wrapper {
     // Referenced by name (not by .class) in the matchers below: ExchangeFunction is only on
@@ -33,16 +35,21 @@ public class SpringWebClientWrapper implements Wrapper {
         return ElementMatchers.hasSuperType(ElementMatchers.named(EXCHANGE_FUNCTION_CLASS_NAME));
     }
     public static class SpringWebClientAdvice {
-        @Advice.OnMethodEnter(suppress = Throwable.class)
-        public static void before(
-                @Advice.Argument(0) ClientRequest request
+        // Registration happens in onExit, wrapped around the returned Mono via
+        // deferContextual(), rather than eagerly in onEnter. That way it runs at subscribe
+        // time, reading back whatever ContextObject SpringWebfluxWrapper wrote into Reactor's
+        // Context (see ReactorAikidoContext) - reliable regardless of scheduler hops between
+        // the incoming request and this WebClient call, unlike Context.get()'s ThreadLocal.
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void after(
+                @Advice.Argument(0) ClientRequest request,
+                @Advice.Return(readOnly = false) Mono<ClientResponse> returnValue
         ) throws MalformedURLException {
-            if (request == null || request.url() == null) {
+            if (request == null || request.url() == null || returnValue == null) {
                 return;
             }
-            // Report the URL before the request is sent, so DNSRecordCollector can match the
-            // DNS lookup that follows to this outgoing request.
-            URLCollector.report(request.url().toURL());
+            URL url = request.url().toURL();
+            returnValue = (Mono<ClientResponse>) ReactorAikidoContext.deferRegisterUrl(returnValue, url);
         }
     }
 }

--- a/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebfluxWrapper.java
+++ b/agent/src/main/java/dev/aikido/agent/wrappers/spring/SpringWebfluxWrapper.java
@@ -55,6 +55,12 @@ public class SpringWebfluxWrapper implements Wrapper {
     public record SkipOnWrapper(Mono<Void> newReturnValue) {
     }
 
+    // Non-skip path result: carries the ContextObject alongside the response so onExit() can
+    // write it into Reactor's own Context (see ReactorAikidoContext), letting it survive
+    // scheduler hops before any WebClient call made while handling this request.
+    public record EnterResult(ServerHttpResponse res, ContextObject context) {
+    }
+
     public static class SpringWebfluxAdvice {
         @Advice.OnMethodEnter(skipOn = SkipOnWrapper.class, suppress = Throwable.class)
         public static Object onEnter(
@@ -94,7 +100,7 @@ public class SpringWebfluxWrapper implements Wrapper {
                 return new SkipOnWrapper(res.writeWith(Mono.just(dataBuffer)));
             }
 
-            return res; // Return to analyze status code in OnMethodExit.
+            return new EnterResult(res, context); // Return to analyze status code in OnMethodExit.
         }
 
         /** onExit()
@@ -105,16 +111,19 @@ public class SpringWebfluxWrapper implements Wrapper {
                 @Advice.Enter Object enterResult,
                 @Advice.Return(readOnly = false) Mono<Void> returnValue
         ) {
-            // enterResult can be two things : Either the SkipOnWrapper or the ServerHttpResponse
-            // ServerHttpResponse -> Extract status code.
+            // enterResult can be two things : Either the SkipOnWrapper or the EnterResult
+            // EnterResult -> Extract status code, write the context into Reactor's Context.
             // SkipOnWrapper -> we blocked a request (e.g. IP Blocking), and are returning the value below
             if (enterResult instanceof SkipOnWrapper wrapper && wrapper.newReturnValue() != null) {
                 returnValue = wrapper.newReturnValue();
-            } else if (enterResult instanceof ServerHttpResponse res) {
+            } else if (enterResult instanceof EnterResult er) {
                 // Report status code of response :
-                Integer statusCode = res.getRawStatusCode();
+                Integer statusCode = er.res() != null ? er.res().getRawStatusCode() : null;
                 if (statusCode != null) {
                     WebResponseCollector.report(statusCode);
+                }
+                if (returnValue != null) {
+                    returnValue = (Mono<Void>) ReactorAikidoContext.write(returnValue, er.context());
                 }
             }
         }

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -1,6 +1,7 @@
 package dev.aikido.agent_api.collectors;
 
 import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.context.ContextObject;
 import dev.aikido.agent_api.storage.HostnamesStore;
 import dev.aikido.agent_api.storage.PendingHostnamesStore;
 import dev.aikido.agent_api.storage.ServiceConfigStore;
@@ -32,7 +33,8 @@ public final class DNSRecordCollector {
 
     public static void report(String hostname, InetAddress[] inetAddresses) {
         // InetAddress.getAllByName() resolves everything in one call, so it's safe to consume.
-        process(hostname, inetAddresses, PendingHostnamesStore.getAndRemove(hostname), INET_ADDRESS_OPERATION_NAME);
+        withCapturedContext(hostname, () ->
+                process(hostname, inetAddresses, PendingHostnamesStore.getAndRemove(hostname), INET_ADDRESS_OPERATION_NAME));
     }
 
     // For clients that resolve their own DNS (e.g. Reactor Netty, used by Spring's WebClient) or
@@ -40,7 +42,31 @@ public final class DNSRecordCollector {
     // the same hostname (IPv4 then IPv6), so unlike report(), this peeks the pending port instead
     // of consuming it - consuming on the first attempt would let a later attempt bypass SSRF.
     public static void reportConnect(String hostname, InetAddress resolvedAddress) {
-        process(hostname, new InetAddress[]{resolvedAddress}, PendingHostnamesStore.getPorts(hostname), SOCKET_CHANNEL_OPERATION_NAME);
+        withCapturedContext(hostname, () ->
+                process(hostname, new InetAddress[]{resolvedAddress}, PendingHostnamesStore.getPorts(hostname), SOCKET_CHANNEL_OPERATION_NAME));
+    }
+
+    // Restores the ContextObject captured when this hostname's pending entry was registered
+    // (PendingHostnamesStore is global, not thread-local) so SSRFDetector's Context.get() sees
+    // the request that actually triggered the outbound call, even if we're running on a
+    // different thread than the one that registered it.
+    private static void withCapturedContext(String hostname, Runnable action) {
+        ContextObject capturedContext = PendingHostnamesStore.getContext(hostname);
+        if (capturedContext == null) {
+            action.run();
+            return;
+        }
+        ContextObject previous = Context.get();
+        Context.set(capturedContext);
+        try {
+            action.run();
+        } finally {
+            if (previous != null) {
+                Context.set(previous);
+            } else {
+                Context.reset();
+            }
+        }
     }
 
     private static void process(String hostname, InetAddress[] inetAddresses, Set<Integer> ports, String operationName) {

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/URLCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/URLCollector.java
@@ -1,5 +1,7 @@
 package dev.aikido.agent_api.collectors;
 
+import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.context.ContextObject;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
 import dev.aikido.agent_api.storage.PendingHostnamesStore;
@@ -13,6 +15,13 @@ public final class URLCollector {
 
     private URLCollector() {}
     public static void report(URL url) {
+        report(url, Context.get());
+    }
+
+    // Used where the caller already resolved the correct context itself instead of relying on
+    // Context.get() (e.g. Spring WebClient reading it back from Reactor's own Context, which
+    // survives scheduler hops that break Context.get()'s ThreadLocal).
+    public static void report(URL url, ContextObject context) {
         if (url != null) {
             if (!url.getProtocol().startsWith("http")) {
                 return; // Non-HTTP(S) URL
@@ -20,7 +29,7 @@ public final class URLCollector {
             logger.trace("Adding a new URL to the cache: %s", url);
             // Store hostname+port in the pending store so DNSRecordCollector can pick it
             // up during the DNS lookup that follows, for SSRF detection and outbound hostnames
-            PendingHostnamesStore.add(url.getHost(), getPortFromURL(url));
+            PendingHostnamesStore.add(url.getHost(), getPortFromURL(url), context);
         }
     }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/WebRequestCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/WebRequestCollector.java
@@ -8,7 +8,6 @@ import dev.aikido.agent_api.context.RouteMetadata;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
 import dev.aikido.agent_api.storage.AttackQueue;
-import dev.aikido.agent_api.storage.PendingHostnamesStore;
 import dev.aikido.agent_api.storage.ServiceConfigStore;
 import dev.aikido.agent_api.storage.ServiceConfiguration;
 import dev.aikido.agent_api.storage.attack_wave_detector.AttackWaveDetectorStore;
@@ -40,10 +39,6 @@ public final class WebRequestCollector {
 
         // clear context
         Context.reset();
-
-        // Flush pending hostnames on every context change to prevent the store from
-        // growing unboundedly when a thread is reused across multiple requests.
-        PendingHostnamesStore.clear();
 
         if (config.isIpBypassed(newContext.getRemoteAddress())) {
             return null; // do not set context when the IP address is bypassed (zen = off)

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/PendingHostnamesStore.java
@@ -1,9 +1,12 @@
 package dev.aikido.agent_api.storage;
 
+import dev.aikido.agent_api.context.Context;
+import dev.aikido.agent_api.context.ContextObject;
+
 import java.util.*;
 
 /**
- * Thread-local bridge between URLCollector and DNSRecordCollector.
+ * Bridge between URLCollector and DNSRecordCollector.
  * URLCollector records hostname+port here; DNSRecordCollector.report() (fed by
  * InetAddress.getAllByName(), which resolves everything in one call) reads and removes the
  * entry so each (hostname, port) pair is processed exactly once per DNS lookup.
@@ -11,49 +14,77 @@ import java.util.*;
  * connect attempt) instead peeks the entry, since a single outbound request can trigger
  * multiple connect attempts to the same hostname (e.g. IPv4 then IPv6 for a dual-stack host).
  *
- * Entries are normally cleared per incoming request by WebRequestCollector, but a peeked
- * entry added outside any incoming-request context (e.g. a WebClient call from a @Scheduled
- * task) would never be cleared that way. Capped at MAX_ENTRIES per thread, evicting the least
- * recently used entry once exceeded, same bounded-LRU pattern as Hostnames.
+ * Global rather than thread-local: for async clients (e.g. Spring's WebClient/Reactor Netty),
+ * the intent registration and the actual connect can run on different OS threads - Reactor
+ * Netty's own event-loop dispatch, or an app's explicit .publishOn() - so thread-local storage
+ * silently loses the entry. Trade-off: two concurrent requests to the *same* hostname can share
+ * an entry (and its captured context) in a narrow race window. This doesn't open an SSRF bypass
+ * (SSRFDetector/StoredSSRFDetector still run unconditionally either way) - worst case is a wrong
+ * source attribution for that one request.
+ *
+ * Capped at MAX_ENTRIES, evicting the least recently used entry once exceeded, so it can't grow
+ * unboundedly under load or from entries that are never consumed (e.g. a WebClient call from a
+ * @Scheduled task, outside any incoming-request context).
  */
 public final class PendingHostnamesStore {
     private PendingHostnamesStore() {}
 
     private static final int MAX_ENTRIES = 1000;
 
-    private static final ThreadLocal<Map<String, Set<Integer>>> store =
-            ThreadLocal.withInitial(() -> new LinkedHashMap<>(16, 0.75f, true) {
+    private record Entry(Set<Integer> ports, ContextObject context) {}
+
+    private static final Map<String, Entry> store =
+            Collections.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
                 @Override
-                protected boolean removeEldestEntry(Map.Entry<String, Set<Integer>> eldest) {
+                protected boolean removeEldestEntry(Map.Entry<String, Entry> eldest) {
                     return size() > MAX_ENTRIES;
                 }
             });
 
     public static void add(String hostname, int port) {
-        Map<String, Set<Integer>> map = store.get();
-        if (!map.containsKey(hostname)) {
-            map.put(hostname, new LinkedHashSet<>());
+        add(hostname, port, Context.get());
+    }
+
+    // Used where the caller already resolved the correct context itself (e.g. via Reactor's own
+    // Context, which - unlike Context.get()'s ThreadLocal - survives scheduler hops).
+    public static void add(String hostname, int port, ContextObject context) {
+        synchronized (store) {
+            Entry existing = store.get(hostname);
+            if (existing == null) {
+                Set<Integer> ports = new LinkedHashSet<>();
+                ports.add(port);
+                store.put(hostname, new Entry(ports, context));
+            } else {
+                existing.ports().add(port);
+            }
         }
-        map.get(hostname).add(port);
     }
 
     public static Set<Integer> getAndRemove(String hostname) {
-        Set<Integer> ports = store.get().remove(hostname);
-        if (ports == null) {
-            return Collections.emptySet();
+        synchronized (store) {
+            Entry entry = store.remove(hostname);
+            return entry == null ? Collections.emptySet() : entry.ports();
         }
-        return ports;
     }
 
     public static Set<Integer> getPorts(String hostname) {
-        Set<Integer> ports = store.get().get(hostname);
-        if (ports == null) {
-            return Collections.emptySet();
+        synchronized (store) {
+            Entry entry = store.get(hostname);
+            return entry == null ? Collections.emptySet() : Set.copyOf(entry.ports());
         }
-        return Collections.unmodifiableSet(ports);
+    }
+
+    // The ContextObject captured when this hostname's pending entry was registered, so SSRF
+    // taint-checking can use the request that actually triggered the outbound call even if it
+    // runs on a different thread than the one processing the connect. Null if none was captured.
+    public static ContextObject getContext(String hostname) {
+        synchronized (store) {
+            Entry entry = store.get(hostname);
+            return entry == null ? null : entry.context();
+        }
     }
 
     public static void clear() {
-        store.get().clear();
+        store.clear();
     }
 }

--- a/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
+++ b/agent_api/src/test/java/storage/PendingHostnamesStoreTest.java
@@ -1,8 +1,10 @@
 package storage;
 
+import dev.aikido.agent_api.context.ContextObject;
 import dev.aikido.agent_api.storage.PendingHostnamesStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import utils.EmptySampleContextObject;
 
 import java.util.Set;
 
@@ -32,7 +34,7 @@ public class PendingHostnamesStoreTest {
     }
 
     @Test
-    public void testUnboundedHostnamesDoNotGrowThreadLocalMapForever() {
+    public void testUnboundedHostnamesDoNotGrowMapForever() {
         // Regression test: entries added outside any incoming-request context (e.g. a
         // WebClient call from a @Scheduled task) never get cleared by WebRequestCollector's
         // per-request clear(). Adding well over the internal cap of distinct hostnames must
@@ -66,6 +68,34 @@ public class PendingHostnamesStoreTest {
             PendingHostnamesStore.add("host-" + i + ".example.com", 443);
         }
         assertEquals(Set.of(443), PendingHostnamesStore.getPorts("dual-stack.example.com"));
+    }
+
+    @Test
+    public void testEntryIsVisibleFromADifferentThread() throws InterruptedException {
+        // The whole point of this store being global instead of thread-local: WebClient's
+        // "register intent" and "actual connect" steps can run on different OS threads
+        // (Reactor Netty's own event-loop dispatch, or an app's own .publishOn()).
+        Thread writer = new Thread(() -> PendingHostnamesStore.add("cross-thread.example.com", 443));
+        writer.start();
+        writer.join();
+
+        Set<Integer> portsSeenFromThisThread = PendingHostnamesStore.getPorts("cross-thread.example.com");
+        assertEquals(Set.of(443), portsSeenFromThisThread);
+    }
+
+    @Test
+    public void testGetContextReturnsWhatWasCapturedAtAddTime() {
+        ContextObject context = new EmptySampleContextObject();
+        PendingHostnamesStore.add("dev.aikido", 443, context);
+
+        assertSame(context, PendingHostnamesStore.getContext("dev.aikido"));
+    }
+
+    @Test
+    public void testGetContextIsNullWhenNoneWasCaptured() {
+        PendingHostnamesStore.add("dev.aikido", 443, null);
+
+        assertNull(PendingHostnamesStore.getContext("dev.aikido"));
     }
 
     @Test

--- a/agent_api/src/test/java/wrappers/OkHttpTest.java
+++ b/agent_api/src/test/java/wrappers/OkHttpTest.java
@@ -4,6 +4,8 @@ import dev.aikido.agent_api.context.Context;
 import dev.aikido.agent_api.storage.Hostnames;
 import dev.aikido.agent_api.storage.HostnamesStore;
 import dev.aikido.agent_api.storage.ServiceConfigStore;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -15,9 +17,14 @@ import utils.EmptySampleContextObject;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OkHttpTest {
     private OkHttpClient client;
@@ -95,6 +102,48 @@ public class OkHttpTest {
             fetchResponse("http://localhost/api/test");
         });
         assertEquals(1, getHits("localhost", 80));
+    }
+
+    @Test
+    public void testSSRFAsyncEnqueueOnDifferentThread() throws Exception {
+        // newCall() runs on this test thread (intent registered here), but enqueue() executes
+        // the actual call - including the DNS lookup / connect - on OkHttp's own Dispatcher
+        // thread pool, a different thread. Investigating whether PendingHostnamesStore (and
+        // captured Context) survive that hop the same way they need to for WebClient.
+        setContextAndLifecycle("http://localhost:5000");
+        assertEquals(0, getHits("localhost", 5000));
+
+        Request request = new Request.Builder().url("http://localhost:5000").build();
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Integer> responseCode = new AtomicReference<>();
+
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                failure.set(e);
+                latch.countDown();
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) {
+                responseCode.set(response.code());
+                response.close();
+                latch.countDown();
+            }
+        });
+
+        boolean completed = latch.await(5, TimeUnit.SECONDS);
+        assertTrue(completed, "enqueue() callback never fired within 5s");
+
+        if (failure.get() == null) {
+            fail("expected the SSRF block to surface as a failure, got response code: " + responseCode.get());
+        }
+        // OkHttp wraps the cancellation as a new IOException embedding the original exception's
+        // toString() as text, not as a proper getCause() chain, so check the message contains it.
+        String message = failure.get().getMessage();
+        assertTrue(message != null && message.contains("Aikido Zen has blocked a server-side request forgery"),
+                "expected an SSRF block in the failure message, got: " + failure.get());
     }
 
     private void fetchResponse(String urlString) throws IOException {

--- a/agent_api/src/test/java/wrappers/WebClientTest.java
+++ b/agent_api/src/test/java/wrappers/WebClientTest.java
@@ -24,11 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * SpringWebClientWrapper (URLCollector.report on ExchangeFunction.exchange) and
  * SocketChannelWrapper (DNSRecordCollector.reportConnect on SocketChannel.connect) run on
  * different threads for a real WebClient call: the former on the subscribing thread, the
- * latter on Reactor Netty's own event-loop thread. PendingHostnamesStore/Context are
- * ThreadLocal, so a plain "Context.set() then webClient.block()" test can't observe both
- * halves together the way HttpURLConnectionTest can for a same-thread blocking client - that
- * only works in production because a real WebFlux request stays on one reactor-http-nio
- * thread throughout. So this file tests each wrapper's own contribution separately.
+ * latter on Reactor Netty's own event-loop thread. This file can't be a single cohesive test
+ * the way HttpURLConnectionTest is for a same-thread blocking client, and this isn't just a
+ * ThreadLocal limitation fixed by PendingHostnamesStore going global: the taint-context capture
+ * (ReactorAikidoContext) only gets written into Reactor's own Context by SpringWebfluxWrapper,
+ * which only fires for a *real* incoming WebFlux request - a bare "webClient.get()...block()"
+ * call made directly from a test, with no request behind it, never populates it, so the SSRF
+ * check silently no-ops and a real network call goes out (confirmed empirically: it hangs until
+ * timeout instead of getting blocked). A true end-to-end "WebClient in a Spring app, request
+ * gets blocked" test needs an actual running app - see spring_webflux_postgres.py's `ssrf`
+ * payload for that. This file instead tests each wrapper's own contribution in isolation.
  */
 public class WebClientTest {
     private static final WebClient webClient = WebClient.create();

--- a/sample-apps/SpringWebfluxSampleApp/src/main/java/dev/aikido/SpringWebfluxSampleApp/RequestController.java
+++ b/sample-apps/SpringWebfluxSampleApp/src/main/java/dev/aikido/SpringWebfluxSampleApp/RequestController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import reactor.netty.http.client.HttpClient;
 
 @RestController
@@ -45,6 +46,17 @@ public class RequestController {
                 .onErrorResume(e -> isAikidoBlock(e)
                         ? Mono.error(e)
                         : Mono.just("Error: " + e.getMessage()));
+    }
+
+    // Exercises a scheduler hop (a common pattern for mixing blocking JDBC with reactive
+    // controllers) BEFORE the WebClient call, to test whether ThreadLocal-based taint/port
+    // correlation survives moving off the original reactor-http-nio thread. Unverified
+    // hypothesis, see PR #312 worklog item 2.
+    @GetMapping("/publish-on")
+    public Mono<String> makeRequestWithSchedulerHop(@RequestParam String url) {
+        return Mono.just(url)
+                .publishOn(Schedulers.boundedElastic())
+                .flatMap(this::makeRequestInternal);
     }
 
     private Mono<String> makeRequestInternal(String url) {


### PR DESCRIPTION
## Context

Follow-up to #312. Hans's review there flagged `ports.isEmpty()` (used to distinguish real requests from infra noise in `DNSRecordCollector`) as not fully reliable. #312 fixed the one concrete case found at the time (WebClient redirects) and left the general problem as a documented, unverified hypothesis.

This PR closes that gap for real: `Context`/`PendingHostnamesStore` were `ThreadLocal`, which only survives when a WebClient call's "intent" (registering the pending host+port) and its "effect" (the actual socket connect) run on the *same* OS thread. That holds for the default WebFlux request-handling flow, but breaks under:
- An app's own explicit scheduler switch (`.publishOn(Schedulers.boundedElastic())` before a `WebClient` call - a common pattern for mixing blocking JDBC with reactive controllers).
- Reactor Netty's *own* internal event-loop dispatch (subscribing thread → `reactor-http-nio` thread) - separate from any app-level scheduler hop.

**Confirmed via e2e before investing in a fix, not just reasoned about on paper.** Added a test endpoint (`/api/request/publish-on`, `Mono.just(url).publishOn(Schedulers.boundedElastic()).flatMap(...)`) targeting the same private IP (`169.254.169.254`) used elsewhere in #312's e2e tests:
- Without the hop: blocked, HTTP 500, `SSRF Attack detected due to: 169.254.169.254:80`.
- With the hop: **not blocked** - `URLCollector` registered intent on thread `boundedElastic-1`, `DNSRecordCollector.reportConnect()` ran the check on thread `reactor-http-nio-5`, no SSRF log line at all, the request actually went out over the network (curl hung until timeout).

## What changed

- **`PendingHostnamesStore.java`** - rewritten from `ThreadLocal` to a global, `synchronized`, bounded-LRU map (same 1000-entry cap and eviction policy as before). Each entry now also carries the `ContextObject` that was active when it was registered, not just the ports.

  Trade-off: two concurrent requests to the *same* hostname can now share/overwrite each other's entry in a narrow race window. Doesn't open an SSRF bypass - `SSRFDetector`/`StoredSSRFDetector` still run unconditionally either way - worst case is a wrong source attribution for that one request. This is a real, demonstrated effect and not just theoretical: it broke `RestTemplateTest`/`InetAddressTest` during development (turned out to be an unrelated reflection bug this change exposed, see below, now fixed) - worth keeping an eye on if dashboard source attribution ever looks off for high-traffic shared hostnames.

  Considered an object-identity-keyed alternative (key by the Reactor Netty request-handler object instead of hostname, avoiding the cross-contamination trade-off entirely) but ruled it out: that object isn't reachable from `SpringWebClientWrapper`'s hook point (`ExchangeFunction.exchange()`, Spring's own layer, which runs *before* Reactor Netty constructs its own internal handler for the call).

- **`WebRequestCollector.java`** - removed the per-incoming-request `PendingHostnamesStore.clear()` call. It was a `ThreadLocal`-era safety net ("wipe this thread's leftover entries before handling a new request") that becomes actively harmful now that the store is global - it would wipe *other concurrent requests'* in-flight entries, not just stale ones from a previous request on a reused thread. The bounded-LRU eviction already handles unbounded growth on its own.

- **`ReactorAikidoContext.java`** (new) - bridges the captured `ContextObject` through Reactor's own `Context` (`reactor.util.context.Context`/`ContextView` - not our own `Context` class) so it survives `.publishOn()` between the incoming request and a `WebClient` call made while handling it. `SpringWebfluxWrapper` writes it via `.contextWrite()`; `SpringWebClientWrapper` reads it back via `.deferContextual()` at `ExchangeFunction.exchange()` time and passes it into `PendingHostnamesStore` alongside the port. `DNSRecordCollector.report()`/`reportConnect()` temporarily restore that captured context around the SSRF check, so it's used regardless of which thread actually ends up processing the connect.

  Everything in this class goes through reflection rather than a static type reference to `reactor.util.context.*`. `reactor-core` is `compileOnly` for this module: unlike `@Advice`-bound parameter types (which ByteBuddy resolves specially against the *woven target's own* classloader), a normal helper class that declares `Context`/`ContextView` as a concrete parameter type fails to verify at all on the agent's own classloader, which has no visibility into the target app's classpath - confirmed by hitting exactly that `NoClassDefFoundError` on the first attempt. A second attempt using lambdas for the `Function` callbacks hit a *different* problem: ByteBuddy inlines `@Advice` bytecode into the target class, so a lambda constructed there becomes a private synthetic method that the target class can't call back into (`IllegalAccessError`) - same class of bug already hit once in #312 with `SpringWebClientRedirectWrapper`'s `externalForm` helper. Fixed with a plain, `public`, `Object`-typed `InvocationHandler` class instead of a lambda.

- Considered `io.micrometer:context-propagation` first (Micrometer's `ThreadLocalAccessor` API, purpose-built for this). Dropped it: it only helps if the target app already happens to have that optional library on its classpath, which can't be required or forced - the agent can't add a hard dependency that isn't guaranteed present. The fix above needs nothing beyond `reactor-core`, which is guaranteed present wherever `WebClient` is.

- **Incidental bugfix found while testing this**: `HttpURLConnectionWrapper` and `HttpClientSendWrapper` locate `URLCollector.report` via reflection, matching by method name only (`clazz.getMethods()` + `.getName().equals("report")`). Adding the new `report(URL, ContextObject)` overload made this ambiguous - depending on JVM method-ordering, it could silently pick the wrong overload, throw an `IllegalArgumentException` on the argument-count mismatch, and (since both wrappers run with `suppress = Throwable.class`) fail *completely silently*, breaking outbound tracking/SSRF for plain `HttpURLConnection`/`java.net.http.HttpClient` users. Caught by `RestTemplateTest`/`InetAddressTest` failing during development. Fixed by looking up the exact single-argument overload (`clazz.getMethod("report", URL.class)`) instead of matching by name.

## e2e scenario tested

Same setup as #312 (real agent, real Spring WebFlux sample app, mock core):

**SSRF via WebClient after an explicit scheduler hop, now blocked:**
```bash
curl -G "http://localhost:8090/api/request/publish-on" --data-urlencode "url=http://169.254.169.254/latest/meta-data/"
```
→ HTTP 500, `SSRF Attack detected due to: 169.254.169.254:80`, `source=query`. Log confirms the cross-thread path: `URLCollector` registers intent on thread `boundedElastic-1`, `DNSRecordCollector.reportConnect()` runs the check on thread `reactor-http-nio-5` - different threads, correctly correlated.

Also re-ran all of #312's existing e2e scenarios (safe request, literal-IP SSRF, dual-stack, redirect) to confirm no regressions - all still pass.

## Tests

New `PendingHostnamesStoreTest` cases:
- `testEntryIsVisibleFromADifferentThread` - the actual point of making the store global: writes on one thread, reads on another, confirms the entry is visible.
- `testGetContextReturnsWhatWasCapturedAtAddTime` / `testGetContextIsNullWhenNoneWasCaptured` - the captured-`ContextObject` half of an entry.
- Renamed `testUnboundedHostnamesDoNotGrowThreadLocalMapForever` → `testUnboundedHostnamesDoNotGrowMapForever` (no longer thread-local).

Full regression pass: 1036 tests, same 42 pre-existing environmental failures (network/DB dependent, unavailable in sandbox) as #312's baseline, zero new failures.

New `OkHttpTest.testSSRFAsyncEnqueueOnDifferentThread` - a separate customer report surfaced the same class of bug via `OkHttpClient`: `newCall()` registers intent on the calling thread, but `call.enqueue()` (async) runs the actual connect on OkHttp's own Dispatcher thread pool, a different thread. This PR's `PendingHostnamesStore` fix is generic, not Spring/Reactor-specific, so it turns out to already cover this case with no OkHttp-specific changes needed - confirmed by running the same test against the base branch first (fails: real network call goes out unblocked) and then this branch (passes).

## Addendum: tried to close a #312 review comment fully, found a real limit

Hans's review on #312 also asked for something matching `HttpURLConnectionTest`'s pattern - a single JUnit test where a real client call to a private IP gets blocked, no splitting needed. #312 couldn't do that for `WebClient` (had to split `WebClientTest` into two tests) because of the `ThreadLocal` thread-hop problem this PR fixes - so tried writing that single test here, assuming it'd now work.

It doesn't, and not for a reason this PR can fix: `ReactorAikidoContext`'s taint-context capture only gets written into Reactor's own `Context` by `SpringWebfluxWrapper`, which only fires for a *real* incoming WebFlux request. A bare `webClient.get().uri(privateIP)...block()` call made directly from a JUnit test, with no request behind it, never populates it - confirmed empirically, the request actually went out over the network and hung until timeout instead of getting blocked. Unlike `HttpURLConnectionTest` (whose SSRF check never depended on any request-scoped context propagation beyond a plain `ThreadLocal` on the same thread), this fix inherently needs a real Spring request context to exist.

The correct test for "WebClient in a Spring app gets blocked" is what already exists: `spring_webflux_postgres.py`'s `ssrf` payload (from #312) plus this PR's own scheduler-hop e2e scenario, both against the real running sample app. Documented this in `WebClientTest.java`'s javadoc so it doesn't get re-litigated in review as "why isn't this just one test".

## Known remaining limitations (unchanged from #312, not addressed here)

- **CRITICAL, found while investigating this PR's own CI failures: `SocketChannelWrapper` never fires under Netty's native epoll transport (Linux's default) - see #312's worklog item 1 for the full writeup.** `EpollSocketChannel` implements Netty's own `io.netty.channel.socket.SocketChannel`, not the JDK's `java.nio.channels.SocketChannel` our matcher targets, despite the identical simple name. WebClient traffic is completely untracked/unprotected under this transport, which is why this PR's own `SpringWebfluxSampleApp` e2e job fails 100% of the time in CI while passing locally on macOS (native epoll lib present but fails to load there, silent fallback to plain NIO masks the gap). Not yet fixed - candidate direction noted in #312.
- Spring's `RestClient` (6.1+) instrumentation status is still unverified.
- `IsPrivateIP.isPrivateIp()`'s handling of exotic private-IP encodings (decimal/octal, IPv4-mapped IPv6) is still unverified.
- Spring WebFlux still has no request-body taint tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added ReactorAikidoContext to carry ContextObject through Reactor Context

**🐛 Bugfixes**
* Replaced ThreadLocal store with global synchronized LRU storing context
* Fixed reflection lookup to invoke exact URLCollector.report(URL) overload

**🔧 Refactors**
* Updated WebFlux/WebClient wrappers to write/read Context via Reactor Context


<sup>[More info](https://app.aikido.dev/featurebranch/scan/141162802?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->
