### PR TITLE
Add Java 25 support

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -51,6 +51,11 @@ jobs:
           - { name: SpringBootHyperSQL, test_file: end2end/spring_boot_hypersql.py, db: "" }
         java-version: [17, 18, 19, 20, 21, 24, 25]
         distribution: ['adopt', 'corretto', 'oracle']
+        exclude:
+          # Spring Boot 2.7 uses the legacy javax stack and does not support JDK 25;
+          # keep this app on Java 17-24 only (its javax coverage stays exercised there).
+          - app: { name: SpringBoot2.7Postgres, test_file: end2end/spring_boot_2.7_postgres.py, db: postgres_database }
+            java-version: 25
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -49,7 +49,7 @@ jobs:
           - { name: JavalinMySQLKotlin, test_file: end2end/javalin_mysql_kotlin.py, db: mysql_database }
           - { name: SpringBoot2.7Postgres, test_file: end2end/spring_boot_2.7_postgres.py, db: postgres_database }
           - { name: SpringBootHyperSQL, test_file: end2end/spring_boot_hypersql.py, db: "" }
-        java-version: [17, 18, 19, 20, 21, 24]
+        java-version: [17, 18, 19, 20, 21, 24, 25]
         distribution: ['adopt', 'corretto', 'oracle']
     steps:
       - name: Download build artifacts

--- a/.github/workflows/gradle-tests.yml
+++ b/.github/workflows/gradle-tests.yml
@@ -41,7 +41,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        java-version: [17, 18, 19, 20, 21, 24]
+        java-version: [17, 18, 19, 20, 21, 24, 25]
         distribution: ['adopt', 'corretto', 'oracle']
 
     steps:

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':agent_api')
-    implementation 'net.bytebuddy:byte-buddy:1.15.11'
+    implementation 'net.bytebuddy:byte-buddy:1.18.11'
     // Compile only for interface types :
     compileOnly 'jakarta.servlet:jakarta.servlet-api:6.1.0' // spring 3 -> jakarta
     compileOnly 'javax.servlet:javax.servlet-api:4.0.1' // spring 2 -> javax

--- a/agent/build.gradle
+++ b/agent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id 'com.gradleup.shadow' version '9.5.1'
 }
 
 dependencies {

--- a/agent/src/main/java/dev/aikido/agent/Agent.java
+++ b/agent/src/main/java/dev/aikido/agent/Agent.java
@@ -31,8 +31,8 @@ public class Agent {
             logger.error("Zen by Aikido requires Java 17 or newer. Current version: %d. The agent will not be loaded.", javaVersion);
             return;
         }
-        if (javaVersion > 24) {
-            logger.error("Zen by Aikido does not support Java %d (max supported version: 24). The agent will not be loaded.", javaVersion);
+        if (javaVersion > 25) {
+            logger.error("Zen by Aikido does not support Java %d (max supported version: 25). The agent will not be loaded.", javaVersion);
             return;
         }
         logger.info("Zen by Aikido v%s starting.", Config.pkgVersion);

--- a/agent_api/build.gradle
+++ b/agent_api/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.github.johnrengelman.shadow' version '7.1.0'
+    id 'com.gradleup.shadow' version '9.5.1'
 }
 
 jacoco {

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ subprojects {
     tasks.withType(JavaCompile) {
         options.encoding = 'UTF-8'
     }
-    sourceCompatibility = '16'
-    targetCompatibility = '16'
+    java {
+        sourceCompatibility = JavaVersion.VERSION_16
+        targetCompatibility = JavaVersion.VERSION_16
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Oct 10 12:48:48 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-apps/JavalinMySQLKotlin/pom.xml
+++ b/sample-apps/JavalinMySQLKotlin/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <kotlin.version>1.8.0</kotlin.version> <!-- Change to a stable version -->
+        <kotlin.version>2.2.20</kotlin.version> <!-- 2.2.x required for JDK 25 -->
         <log4j2-version>2.24.3</log4j2-version>
     </properties>
 

--- a/sample-apps/JavalinPostgres/build.gradle
+++ b/sample-apps/JavalinPostgres/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.gradleup.shadow' version '9.5.1'
 }
 
 group = 'dev.aikido'

--- a/sample-apps/JavalinPostgres/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/JavalinPostgres/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Dec 17 13:31:53 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample-apps/SpringBootHyperSQL/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringBootHyperSQL/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringBootMSSQL/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringBootMSSQL/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringBootMySQL/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringBootMySQL/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringBootPostgres/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringBootPostgres/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringMVCPostgresGroovy/build.gradle
+++ b/sample-apps/SpringMVCPostgresGroovy/build.gradle
@@ -8,6 +8,10 @@ plugins {
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
+// Spring Boot 3.4.1 manages an older Groovy 4.0.x whose ASM can't run on JDK 25;
+// Groovy 4.0.27+ adds Java 25 support.
+ext['groovy.version'] = '4.0.28'
+
 java {
 	sourceCompatibility = '17'
 	targetCompatibility = '17'

--- a/sample-apps/SpringMVCPostgresGroovy/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringMVCPostgresGroovy/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringMVCPostgresKotlin/build.gradle
+++ b/sample-apps/SpringMVCPostgresKotlin/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-	id 'org.jetbrains.kotlin.jvm' version '2.1.0'
-	id 'org.jetbrains.kotlin.plugin.spring' version '1.9.25'
+	id 'org.jetbrains.kotlin.jvm' version '2.2.20'
+	id 'org.jetbrains.kotlin.plugin.spring' version '2.2.20'
 	id 'war'
 	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'

--- a/sample-apps/SpringMVCPostgresKotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringMVCPostgresKotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/sample-apps/SpringWebfluxSampleApp/gradle/wrapper/gradle-wrapper.properties
+++ b/sample-apps/SpringWebfluxSampleApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What
- Byte Buddy `1.15.11` → `1.18.11` (JDK 25 / class-file v69 support)
- Version gate `> 24` → `> 25` in `Agent.java`
- Java `25` added to unit-test + e2e CI matrices

## Testing
Locally on JDK 25: agent loads, installs instrumentation, and blocks a SQL injection against a Spring Boot app compiled to Java 25 (v69) bytecode. No-Zen instance lets it through.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added Java 25 support by upgrading Byte Buddy and agent gate.
* Added Java 25 to unit and end-to-end CI matrices.
* Excluded Spring Boot 2.7 from Java 25 CI matrix runs.
* Bumped sample-app Gradle wrappers and updated Kotlin and Groovy versions.

**🔧 Refactors**
* Upgraded root Gradle wrapper to 9.6.1 and migrated shadow plugin.
* Moved sourceCompatibility and targetCompatibility into the java{} project convention.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/144342122?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->