### PR TITLE
Replace linear IP blocklist scan with indexed trie lookup

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/IPList.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/helpers/net/IPList.java
@@ -2,15 +2,13 @@ package dev.aikido.agent_api.helpers.net;
 
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
-
-import java.util.HashSet;
-import java.util.Set;
+import inet.ipaddr.format.util.DualIPv4v6Tries;
 
 public class IPList {
-    private Set<IPAddress> ipAddresses;
+    private final DualIPv4v6Tries ipAddresses;
 
     public IPList() {
-        this.ipAddresses = new HashSet<>();
+        this.ipAddresses = new DualIPv4v6Tries();
     }
 
     public void add(String ipOrCIDR) {
@@ -56,12 +54,7 @@ public class IPList {
     }
 
     private boolean containsAddress(IPAddress ipAddress) {
-        for (IPAddress subnet : ipAddresses) {
-            if (subnet.contains(ipAddress)) {
-                return true;
-            }
-        }
-        return false;
+        return ipAddresses.elementContains(ipAddress);
     }
     public int length() {
         return ipAddresses.size();


### PR DESCRIPTION
IPList.containsAddress() scanned every stored subnet/host linearly (O(n)). 

At 300k+ entries this costs ~13.7ms per lookup; 

`isIpBlocked` runs it up to 4x per request. 

Switched to `inet.ipaddr`'s built-in `DualIPv4v6Tries`, giving O(bits) containment lookups (~1.2us at the same scale):

> A compact binary trie (aka compact binary prefix tree, or binary radix trie)... entry length is capped at 128 bits for IPv6 and 32 bits for IPv4. That makes lookup a constant time operation... construction is O(n), in linear proportion to the number of added elements. 

Public API and matches() semantics unchanged; all existing IPListTest cases pass unmodified.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced linear IP set with DualIPv4v6Tries for faster lookups

**🔧 Refactors**
* Refactored containsAddress to use trie elementContains call and preserved semantics


<sup>[More info](https://app.aikido.dev/featurebranch/scan/147790465?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->