### PR TITLE
Skip recording DNS noise for private IP literals with no pending port

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -47,7 +47,7 @@ public final class DNSRecordCollector {
                 HostnamesStore.incrementHits(hostname, 0);
             }
 
-            // Block if the hostname is in the blocked domains list
+            // Checked here, not at the HTTP client, since not all clients are instrumented and port/context isn't always available.
             if (ServiceConfigStore.shouldBlockOutgoingRequest(hostname)) {
                 logger.debug("Blocking DNS lookup for domain: %s", hostname);
                 throw BlockedOutboundException.get();

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -43,7 +43,7 @@ public final class DNSRecordCollector {
                     HostnamesStore.incrementHits(hostname, port);
                 }
             } else if (!IsPrivateIP.isPrivateIp(hostname)) {
-                // We still need to report a hit to the hostname for outbound domain blocking
+                // Literal IPs reach this sink without a real DNS call, so skip private ones as noise.
                 HostnamesStore.incrementHits(hostname, 0);
             }
 

--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -12,6 +12,7 @@ import dev.aikido.agent_api.vulnerabilities.outbound_blocking.BlockedOutboundExc
 import dev.aikido.agent_api.vulnerabilities.ssrf.SSRFException;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
+import dev.aikido.agent_api.vulnerabilities.ssrf.IsPrivateIP;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFDetector;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFException;
 
@@ -41,7 +42,7 @@ public final class DNSRecordCollector {
                 for (int port : ports) {
                     HostnamesStore.incrementHits(hostname, port);
                 }
-            } else {
+            } else if (!IsPrivateIP.isPrivateIp(hostname)) {
                 // We still need to report a hit to the hostname for outbound domain blocking
                 HostnamesStore.incrementHits(hostname, 0);
             }

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -204,6 +204,62 @@ public class DNSRecordCollectorTest {
     }
 
     @Test
+    public void testPrivateIpLiteralWithNoPendingPortNotRecorded() {
+        Context.set(null);
+        DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2});
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPrivateIpLiteralWithNoPendingPortNotRecordedButBlockedInLockdown() {
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        Context.set(null);
+        assertThrows(BlockedOutboundException.class, () ->
+            DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2})
+        );
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPrivateIpLiteralWithPendingPortStillRecordedAndBlockedInLockdown() {
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        PendingHostnamesStore.add("10.20.11.143", 443);
+        Context.set(mock(ContextObject.class));
+
+        assertThrows(BlockedOutboundException.class, () ->
+            DNSRecordCollector.report("10.20.11.143", new InetAddress[]{inetAddress2})
+        );
+        Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
+        assertEquals(1, entries.length);
+        assertEquals(443, entries[0].getPort());
+    }
+
+    @Test
+    public void testSsrfStillDetectedForPrivateIpLiteralWithPendingPort() {
+        ServiceConfigStore.updateBlocking(true);
+        PendingHostnamesStore.add("169.254.169.254", 80);
+        Context.set(new EmptySampleContextObject("http://169.254.169.254:80/latest/meta-data/"));
+
+        Exception exception = assertThrows(SSRFException.class, () ->
+            DNSRecordCollector.report("169.254.169.254", new InetAddress[]{imdsAddress1})
+        );
+        assertEquals("Aikido Zen has blocked a server-side request forgery", exception.getMessage());
+    }
+
+    @Test
+    public void testNamedHostnameResolvingToPrivateIpWithNoPendingPortStillRecorded() {
+        Context.set(null);
+        DNSRecordCollector.report("internal-service.local", new InetAddress[]{inetAddress2});
+        Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
+        assertEquals(1, entries.length);
+        assertEquals("internal-service.local", entries[0].getHostname());
+    }
+
+    @Test
     public void testStoredSSRFWithNoContext() throws InterruptedException {
         ServiceConfigStore.updateBlocking(true);
 


### PR DESCRIPTION
Minimal, smaller version of #317 — skips dashboard noise from private-IP-literal DNS lookups with no pending port, everything else (outbound blocking, SSRF checks, port-based recording) stays unconditional and unchanged.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Skipped recording hostname hits for private IP literals without pending ports

**📚 Documentation**
* Clarified why outbound domain blocking was checked at DNS sink


<sup>[More info](https://app.aikido.dev/featurebranch/scan/153430754?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->