### PR TITLE
Support gradual rollout flag for realtime updates

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/background/BackgroundProcess.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/background/BackgroundProcess.java
@@ -59,8 +59,10 @@ public class BackgroundProcess extends Thread {
         // one time check to report initial stats
         scheduler.schedule(new HeartbeatTask(api, true), 60, TimeUnit.SECONDS);
 
-        if (token != null && FeatureFlags.AIKIDO_FEATURE_SSE.isEnabled()) {
-            new RealtimeSSETask(new RealtimeSSEAPI(token), api).start();
+        if (token != null) {
+            if (FeatureFlags.AIKIDO_FEATURE_SSE.isEnabled() || ServiceConfigStore.isRealtimeUpdatesEnabled()) {
+                new RealtimeSSETask(new RealtimeSSEAPI(token), api).start();
+            }
         }
     }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/APIResponse.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/background/cloud/api/APIResponse.java
@@ -16,6 +16,23 @@ public record APIResponse(
         List<Domain> domains,
         boolean receivedAnyStats,
         boolean block,
-        List<String> excludedUserIdsFromRateLimiting
+        List<String> excludedUserIdsFromRateLimiting,
+        List<String> enabledFeatures
 ) {
+    public APIResponse(
+            boolean success,
+            String error,
+            long configUpdatedAt,
+            List<Endpoint> endpoints,
+            List<String> blockedUserIds,
+            List<String> allowedIPAddresses,
+            boolean blockNewOutgoingRequests,
+            List<Domain> domains,
+            boolean receivedAnyStats,
+            boolean block,
+            List<String> excludedUserIdsFromRateLimiting
+    ) {
+        this(success, error, configUpdatedAt, endpoints, blockedUserIds, allowedIPAddresses, blockNewOutgoingRequests,
+                domains, receivedAnyStats, block, excludedUserIdsFromRateLimiting, List.of());
+    }
 }

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfigStore.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfigStore.java
@@ -41,6 +41,15 @@ public final class ServiceConfigStore {
         }
     }
 
+    public static boolean isRealtimeUpdatesEnabled() {
+        mutex.readLock().lock();
+        try {
+            return config.isRealtimeUpdatesEnabled();
+        } finally {
+            mutex.readLock().unlock();
+        }
+    }
+
     public static void updateFromAPIResponse(APIResponse apiResponse) {
         mutex.writeLock().lock();
         try {

--- a/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/storage/ServiceConfiguration.java
@@ -25,6 +25,7 @@ public class ServiceConfiguration {
     private IPList bypassedIPs = new IPList();
     private HashSet<String> blockedUserIDs = new HashSet<>();
     private HashSet<String> excludedUserIdsFromRateLimiting = new HashSet<>();
+    private HashSet<String> enabledFeatures = new HashSet<>();
     private List<Endpoint> endpoints = new ArrayList<>();
     private OutboundDomains outboundDomains = new OutboundDomains();
 
@@ -47,6 +48,9 @@ public class ServiceConfiguration {
         if (apiResponse.excludedUserIdsFromRateLimiting() != null) {
             this.excludedUserIdsFromRateLimiting = new HashSet<>(apiResponse.excludedUserIdsFromRateLimiting());
         }
+        if (apiResponse.enabledFeatures() != null) {
+            this.enabledFeatures = new HashSet<>(apiResponse.enabledFeatures());
+        }
         if (apiResponse.endpoints() != null) {
             this.endpoints = apiResponse.endpoints();
         }
@@ -56,6 +60,10 @@ public class ServiceConfiguration {
 
     public boolean isBlockingEnabled() {
         return blockingEnabled;
+    }
+
+    public boolean isRealtimeUpdatesEnabled() {
+        return enabledFeatures.contains("realtime_updates");
     }
 
     public void setBlocking(boolean block) {

--- a/agent_api/src/test/java/storage/ServiceConfigStoreTest.java
+++ b/agent_api/src/test/java/storage/ServiceConfigStoreTest.java
@@ -58,4 +58,18 @@ public class ServiceConfigStoreTest {
         ));
         assertTrue(ServiceConfigStore.shouldBlockOutgoingRequest("unknown.com"));
     }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledFalseByDefault() {
+        assertFalse(ServiceConfigStore.isRealtimeUpdatesEnabled());
+    }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledTrueWhenEnabled() {
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, List.of("realtime_updates")
+        ));
+        assertTrue(ServiceConfigStore.isRealtimeUpdatesEnabled());
+    }
 }

--- a/agent_api/src/test/java/storage/ServiceConfigurationTest.java
+++ b/agent_api/src/test/java/storage/ServiceConfigurationTest.java
@@ -665,4 +665,58 @@ public class ServiceConfigurationTest {
         assertTrue(resultBlocked.blocked());
         assertFalse(resultNotAllowedLocal.blocked());
     }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledDefaultsFalse() {
+        assertFalse(serviceConfiguration.isRealtimeUpdatesEnabled());
+    }
+
+    @Test
+    public void testUpdateConfigWithNullEnabledFeaturesDoesNotThrow() {
+        APIResponse apiResponse = new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, null
+        );
+        assertDoesNotThrow(() -> serviceConfiguration.updateConfig(apiResponse));
+        assertFalse(serviceConfiguration.isRealtimeUpdatesEnabled());
+    }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledTrueWhenPresent() {
+        APIResponse apiResponse = new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, List.of("realtime_updates")
+        );
+        serviceConfiguration.updateConfig(apiResponse);
+
+        assertTrue(serviceConfiguration.isRealtimeUpdatesEnabled());
+    }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledFalseWhenRemoved() {
+        APIResponse enabled = new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, List.of("realtime_updates")
+        );
+        serviceConfiguration.updateConfig(enabled);
+        assertTrue(serviceConfiguration.isRealtimeUpdatesEnabled());
+
+        APIResponse disabled = new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, List.of()
+        );
+        serviceConfiguration.updateConfig(disabled);
+        assertFalse(serviceConfiguration.isRealtimeUpdatesEnabled());
+    }
+
+    @Test
+    public void testIsRealtimeUpdatesEnabledFalseForUnrelatedFeature() {
+        APIResponse apiResponse = new APIResponse(
+                true, null, 0L, null, null, null,
+                false, null, true, false, null, List.of("some_other_feature")
+        );
+        serviceConfiguration.updateConfig(apiResponse);
+
+        assertFalse(serviceConfiguration.isRealtimeUpdatesEnabled());
+    }
 }


### PR DESCRIPTION
Backend can now enable realtime updates per-account via an `enabledFeatures` list on the config response, ahead of `AIKIDO_FEATURE_SSE` being set locally. SSE starts if either is true.

Mirrors the change already merged in firewall-node and firewall-ruby. Feature name is `realtime_updates`, matching the backend.

`APIResponse` keeps an 11-arg constructor defaulting `enabledFeatures` to empty, so the ~25 existing call sites in tests are untouched.

Testing:
- Unit tests on `ServiceConfiguration`/`ServiceConfigStore`: defaults to false, true when present, false again once removed, false for an unrelated feature name