### PR TITLE
Skip recording DNS noise for all IP literals with no pending port

### DIFF
--- a/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
+++ b/agent_api/src/main/java/dev/aikido/agent_api/collectors/DNSRecordCollector.java
@@ -12,7 +12,7 @@ import dev.aikido.agent_api.vulnerabilities.outbound_blocking.BlockedOutboundExc
 import dev.aikido.agent_api.vulnerabilities.ssrf.SSRFException;
 import dev.aikido.agent_api.helpers.logging.LogManager;
 import dev.aikido.agent_api.helpers.logging.Logger;
-import dev.aikido.agent_api.vulnerabilities.ssrf.IsPrivateIP;
+import dev.aikido.agent_api.helpers.net.IPValidator;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFDetector;
 import dev.aikido.agent_api.vulnerabilities.ssrf.StoredSSRFException;
 
@@ -42,8 +42,9 @@ public final class DNSRecordCollector {
                 for (int port : ports) {
                     HostnamesStore.incrementHits(hostname, port);
                 }
-            } else if (!IsPrivateIP.isPrivateIp(hostname)) {
-                // Literal IPs reach this sink without a real DNS call, so skip private ones as noise.
+            } else if (!IPValidator.isIP(hostname)) {
+                // Skip literal IPs with no pending port: usually inbound IP parsing rather than an outbound request,
+                // and we can't tell them apart here. A real outbound one still hits the blocking/SSRF checks below.
                 HostnamesStore.incrementHits(hostname, 0);
             }
 

--- a/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
+++ b/agent_api/src/test/java/collectors/DNSRecordCollectorTest.java
@@ -260,6 +260,42 @@ public class DNSRecordCollectorTest {
     }
 
     @Test
+    public void testPublicIpLiteralWithNoPendingPortNotRecorded() {
+        Context.set(null);
+        DNSRecordCollector.report("8.8.8.8", new InetAddress[]{inetAddress1});
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPublicIpv6LiteralWithNoPendingPortNotRecorded() {
+        Context.set(null);
+        DNSRecordCollector.report("2606:4700:4700::1111", new InetAddress[]{inetAddress1});
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
+    public void testPublicIpLiteralWithPendingPortStillRecorded() {
+        PendingHostnamesStore.add("8.8.8.8", 443);
+        Context.set(mock(ContextObject.class));
+        DNSRecordCollector.report("8.8.8.8", new InetAddress[]{inetAddress1});
+        Hostnames.HostnameEntry[] entries = HostnamesStore.getHostnamesAsList();
+        assertEquals(1, entries.length);
+        assertEquals(443, entries[0].getPort());
+    }
+
+    @Test
+    public void testPublicIpLiteralWithNoPendingPortNotRecordedButBlockedInLockdown() {
+        ServiceConfigStore.updateFromAPIResponse(new APIResponse(
+            true, null, 0L, null, null, null, true, List.of(), true, true, List.of()
+        ));
+        Context.set(null);
+        assertThrows(BlockedOutboundException.class, () ->
+            DNSRecordCollector.report("8.8.8.8", new InetAddress[]{inetAddress1})
+        );
+        assertEquals(0, HostnamesStore.getHostnamesAsList().length);
+    }
+
+    @Test
     public void testStoredSSRFWithNoContext() throws InterruptedException {
         ServiceConfigStore.updateBlocking(true);
 


### PR DESCRIPTION
Follow-up to #325, which only skipped **private** IP literals. The same dashboard noise happens with public ones.

Spring Security's `IpAddressMatcher` (and similar inbound access-control code) parses request IPs via `InetAddress.getByName`, which lands in our `getAllByName` sink with no pending port. So inbound client IPs — private or public — get recorded as outbound connections. This is the case reported in #294.

The change is a one-liner: in the no-pending-port branch, record a hit only when the hostname isn't a literal IP (`IPValidator.isIP`) instead of only skipping private ones. A literal IP with no port is usually inbound IP parsing rather than an outbound request, and we can't tell the two apart at this sink — so we skip it (see the trade-off below).

Everything else stays unconditional and unchanged:
- Outbound blocking and SSRF checks still run for every call.
- Port-based recording is untouched — real outbound requests go through `URLCollector`, which supplies the port.
- Named hosts that resolve to private IPs are still recorded.

**Trade-off:** a genuine outbound request to a literal public IP through a client we don't instrument (no pending port) won't show in outbound telemetry anymore. Blocking and SSRF still run for it, so it's a visibility gap, not a security one. Temporary until outbound is detected at the HTTP-client layer instead of the ambiguous `InetAddress` sink.

**Tests:** public IPv4/IPv6 with no port (not recorded), public IP with a pending port (still recorded), and public IP still blocked in lockdown.
